### PR TITLE
Better composition for fragments

### DIFF
--- a/modules/core/shared/src/main/scala-2/syntax/StringContextOps.scala
+++ b/modules/core/shared/src/main/scala-2/syntax/StringContextOps.scala
@@ -135,8 +135,18 @@ object StringContextOps {
         }
 
       // The final encoder is either `Void.codec` or `a ~ b ~ ...`
+
+      val void = q"_root_.skunk.Void.codec"
+
       val finalEncoder: Tree =
-        encoders.reduceLeftOption((a, b) => q"$a ~ $b").getOrElse(q"_root_.skunk.Void.codec")
+        encoders
+          .reduceLeftOption { (a, b) => 
+            if (a == void && b == void) void else
+            if (a == void) b else
+            if (b == void) a else
+            q"$a ~ $b"
+          }
+          .getOrElse(void)
 
       // We now have what we need to construct a fragment.
       q"_root_.skunk.syntax.StringContextOps.fragmentFromParts($finalParts, $finalEncoder, $origin)"

--- a/modules/core/shared/src/main/scala-3/syntax/StringContextOps.scala
+++ b/modules/core/shared/src/main/scala-3/syntax/StringContextOps.scala
@@ -128,8 +128,8 @@ object StringContextOps {
         if (encoders.isEmpty) '{ Void.codec }
         else encoders.reduceLeft {
           case ('{$a : Encoder[Void]}, '{ $b : Encoder[Void] }) => '{ Void.codec }
-          case ('{$a : Encoder[a]},    '{ $b : Encoder[Void] }) => '{ $a }
-          case ('{$a : Encoder[Void]}, '{ $b : Encoder[b]    }) => '{ $b }
+          case ('{$a : Encoder[a]},    '{ $b : Encoder[Void] }) => a
+          case ('{$a : Encoder[Void]}, '{ $b : Encoder[b]    }) => b
           case ('{$a : Encoder[a]},    '{ $b : Encoder[b]    }) => '{ $a ~ $b }
         }
 

--- a/modules/core/shared/src/main/scala-3/syntax/StringContextOps.scala
+++ b/modules/core/shared/src/main/scala-3/syntax/StringContextOps.scala
@@ -127,7 +127,10 @@ object StringContextOps {
       val finalEnc: Expr[Any] =
         if (encoders.isEmpty) '{ Void.codec }
         else encoders.reduceLeft {
-          case ('{$a : Encoder[a]}, '{ $b : Encoder[b] }) => '{$a ~ $b}
+          case ('{$a : Encoder[Void]}, '{ $b : Encoder[Void] }) => '{ Void.codec }
+          case ('{$a : Encoder[a]},    '{ $b : Encoder[Void] }) => '{ $a }
+          case ('{$a : Encoder[Void]}, '{ $b : Encoder[b]    }) => '{ $b }
+          case ('{$a : Encoder[a]},    '{ $b : Encoder[b]    }) => '{ $a ~ $b }
         }
 
       finalEnc match {


### PR DESCRIPTION
This PR aim to improve developer UX when composing fragments.

The sql interpolator is modified to remove optimize more the composition of `Void` codecs.
* `Void ~ Void -> Void`
* `A    ~ Void -> A`
* `Void ~ B    -> B`
* `A    ~ B    -> A ~ B`

