### PR TITLE
Update link to microsite after move to typelevel org

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Skunk is a data access library for Scala + Postgres.
 
-Please proceed to the [microsite](http://tpolecat.github.io/skunk) for more information.
+Please proceed to the [microsite](https://typelevel.org/skunk/) for more information.
 
 Please drop a :star: if this project interests you. I need encouragement.
 


### PR DESCRIPTION
I just saw that the readme still points to the old URL which is now broken and gives a 404.