### PR TITLE
Make query decoder implicit

### DIFF
--- a/modules/core/shared/src/main/scala/Fragment.scala
+++ b/modules/core/shared/src/main/scala/Fragment.scala
@@ -27,7 +27,7 @@ final case class Fragment[A](
       case Right(s) => s
     } .runA(1).value.combineAll
 
-  def query[B](decoder: Decoder[B]): Query[A, B] =
+  def query[B](implicit decoder: Decoder[B]): Query[A, B] =
     Query(sql, origin, encoder, decoder, isDynamic = false)
 
   def queryDynamic: Query[A, List[Option[String]]] =


### PR DESCRIPTION
The aim of this PR is to make `decoder` inside `Fragment.query` method an implicit parameter. 