### PR TITLE
Automatically drop void encoders from sql

### DIFF
--- a/modules/core/shared/src/main/scala-3/syntax/StringContextOps.scala
+++ b/modules/core/shared/src/main/scala-3/syntax/StringContextOps.scala
@@ -130,6 +130,8 @@ object StringContextOps {
         else if legacyCommandSyntax then encoders.reduceLeft {
           case ('{$a : Encoder[a]}, '{ $b : Encoder[b] }) => '{$a ~ $b}
         } else encoders.reduceRight {
+          case ('{$a : Encoder[Void]}, '{ $b : Encoder[bh *: bt] }) => b
+          case ('{$a : Encoder[a]}, '{ $b : Encoder[Void] }) => a
           case ('{$a : Encoder[a]}, '{ $b : Encoder[bh *: bt] }) => '{$a *: $b}
           case ('{$a : Encoder[a]}, '{ $b : Encoder[b] }) => '{$a *: $b}
         }

--- a/modules/tests/shared/src/test/scala/CommandTest.scala
+++ b/modules/tests/shared/src/test/scala/CommandTest.scala
@@ -75,6 +75,17 @@ class CommandTest extends SkunkTest {
       }
   }
 
+  {
+    @annotation.nowarn
+    val voidsAreRemoved: Command[City] =
+      sql"""
+          INSERT INTO city
+          VALUES ($int4, ${Void.codec}, $varchar, ${bpchar(3)}, $varchar, $int4, ${Void.codec})
+        """.command.contramap {
+              c => (c.id, c.name, c.code, c.district, c.pop)
+            }
+  }
+
   val selectCity: Query[Int, City] =
     sql"""
           SELECT * FROM city


### PR DESCRIPTION
Updated version of #836 but doesn't work on Scala 2. We should also come up with more realistic example cases and add them as tests. The example added in this PR is artificial.