### PR TITLE
Fix Colima support in test containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,6 @@ services:
   # main instance for testing
   postgres:
     image: postgres:11
-    volumes:
-      - ./world/fix_perms.sh:/docker-entrypoint-initdb.d/fix_perms.sh
-      - ./world/world.sql:/docker-entrypoint-initdb.d/world.sql
-      - ./world/ltree.sql:/docker-entrypoint-initdb.d/ltree.sql
-      - ./world/config.sql:/docker-entrypoint-initdb.d/config.sql
     ports:
       - 5432:5432
     environment:

--- a/world/Dockerfile
+++ b/world/Dockerfile
@@ -2,4 +2,7 @@ FROM postgres:11
 ENV POSTGRES_DB world
 ENV POSTGRES_USER jimmy
 ENV POSTGRES_PASSWORD banana
+ADD fix_perms.sh /docker-entrypoint-initdb.d/
 ADD world.sql /docker-entrypoint-initdb.d/
+ADD ltree.sql /docker-entrypoint-initdb.d/
+ADD config.sql /docker-entrypoint-initdb.d/


### PR DESCRIPTION
This seems to be necessary for test containers to initialize Postgres, at least with latest Colima version.