### PR TITLE
Use `skunk-core` artifact in Setup docs

### DIFF
--- a/modules/docs/src/main/laika/tutorial/Setup.md
+++ b/modules/docs/src/main/laika/tutorial/Setup.md
@@ -17,7 +17,7 @@ If you wish to use your own Postgres server you can download `world/world.sql` f
 Create a new project with Skunk as a dependency.
 
 ```scala
-libraryDependencies += "org.tpolecat" %% "skunk-refined" % "@VERSION@"
+libraryDependencies += "org.tpolecat" %% "skunk-core" % "@VERSION@"
 ```
 
 ## IDE Setup


### PR DESCRIPTION
Not sure why it specifically had `skunk-refined`, which is compounded by the fact this artifact wasn't publishing properly until the next release.