### PR TITLE
Use jawn parser on all platforms

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -159,7 +159,7 @@ lazy val circe = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     name := "skunk-circe",
     libraryDependencies ++= Seq(
       "io.circe" %%% "circe-core"   % "0.14.5",
-      "io.circe" %%% "circe-parser" % "0.14.5"
+      "io.circe" %%% "circe-jawn" % "0.14.5"
     )
   )
 

--- a/modules/circe/src/main/scala/JsonCodecs.scala
+++ b/modules/circe/src/main/scala/JsonCodecs.scala
@@ -7,7 +7,7 @@ package circe.codec
 
 import cats.syntax.all._
 import io.circe.{ Json, Encoder => CEncoder, Decoder => CDecoder }
-import io.circe.parser.parse
+import io.circe.jawn.parse
 import skunk.data.Type
 
 trait JsonCodecs {

--- a/modules/tests/shared/src/test/scala/codec/JsonCodecTest.scala
+++ b/modules/tests/shared/src/test/scala/codec/JsonCodecTest.scala
@@ -5,7 +5,7 @@
 package tests
 package codec
 import io.circe.Json
-import io.circe.parser.parse
+import io.circe.jawn.parse
 import skunk._
 import skunk.circe.codec.all._
 


### PR DESCRIPTION
The default JS parser behaves weirdly for numeric types (this will be fixed in next breaking circe release).