### PR TITLE
Add redaction support to encoder and change SkunkException to use it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,5 @@ To run a specific test:
 > sbt
 > test:testOnly tests.simulation.StartupSimTest
 ```
+
+To view spans emitted during test execution, open a browser to http://localhost:16686 and search traces by `Service = SkunkTests`. Alterntively, use http://localhost:16686/search?limit=100&lookback=15m&service=SkunkTests.

--- a/build.sbt
+++ b/build.sbt
@@ -186,6 +186,18 @@ lazy val tests = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       } else Tests.Argument()
     }
   )
+  .jvmSettings(
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "otel4s-java" % otel4sVersion,
+      "io.opentelemetry" % "opentelemetry-exporter-otlp" % openTelemetryVersion % Runtime,
+      "io.opentelemetry" % "opentelemetry-sdk-extension-autoconfigure" % s"${openTelemetryVersion}-alpha" % Runtime
+    ),
+    Test / fork := true,
+    javaOptions ++= Seq(
+      "-Dotel.java.global-autoconfigure.enabled=true",
+      "-Dotel.service.name=SkunkTests",
+    )
+  )
   .jsSettings(
     scalaJSLinkerConfig ~= { _.withESFeatures(_.withESVersion(org.scalajs.linker.interface.ESVersion.ES2018)) },
     Test / scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,4 +65,4 @@ services:
       - 4317:4317
       - 4318:4318
     environment:
-      COLLECTOR_OTLP_ENABLED: true
+      COLLECTOR_OTLP_ENABLED: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
 
   # Jaeger, for tracing
   jaeger:
-    image: jaegertracing/all-in-one:1.8
+    image: jaegertracing/all-in-one:1.35
     ports:
       - 5775:5775/udp
       - 6831:6831/udp
@@ -62,6 +62,7 @@ services:
       - 5778:5778
       - 16686:16686
       - 14268:14268
-      - 9411:9411
+      - 4317:4317
+      - 4318:4318
     environment:
-      COLLECTOR_ZIPKIN_HTTP_PORT: 9411
+      COLLECTOR_OTLP_ENABLED: true

--- a/modules/core/shared/src/main/scala/Codec.scala
+++ b/modules/core/shared/src/main/scala/Codec.scala
@@ -64,6 +64,17 @@ trait Codec[A] extends Encoder[A] with Decoder[A] { outer =>
       override val types: List[Type]         = outer.types
     }
 
+  override def redacted: Codec[A] = {
+    val red0 = outer.redacted
+    new Codec[A] {
+      override def encode(a: A): List[Option[String]] = outer.encode(a)
+      override def encodeWithRedaction(a: A): List[Option[String]] = red0.encodeWithRedaction(a)
+      override def decode(offset: Int, ss: List[Option[String]]): Either[Decoder.Error, A] = outer.decode(offset, ss)
+      override val sql: State[Int, String] = outer.sql
+      override val types: List[Type] = outer.types
+    }
+  }
+
   override def toString: String =
     s"Codec(${types.mkString(", ")})"
 

--- a/modules/core/shared/src/main/scala/Encoder.scala
+++ b/modules/core/shared/src/main/scala/Encoder.scala
@@ -32,9 +32,19 @@ trait Encoder[A] { outer =>
    */
   def encode(a: A): List[Option[Encoded]]
 
+  /**
+    * Returns an encoder that redacts encoded values.
+    */
   def redacted: Encoder[A] =
     new Encoder[A] {
       override def encode(a: A): List[Option[Encoded]] = outer.encode(a).map(_.map(_.redact))
+      override val types: List[Type] = outer.types
+      override val sql: State[Int, String] = outer.sql
+    }
+
+  def unredacted: Encoder[A] =
+    new Encoder[A] {
+      override def encode(a: A): List[Option[Encoded]] = outer.encode(a).map(_.map(_.unredact))
       override val types: List[Type] = outer.types
       override val sql: State[Int, String] = outer.sql
     }

--- a/modules/core/shared/src/main/scala/Encoder.scala
+++ b/modules/core/shared/src/main/scala/Encoder.scala
@@ -42,7 +42,7 @@ trait Encoder[A] { outer =>
   def redacted: Encoder[A] =
     new Encoder[A] {
       override def encode(a: A): List[Option[String]] = outer.encode(a)
-      override def encodeWithRedaction(a: A): List[Option[String]] = outer.encode(a).as(Some("<redacted>"))
+      override def encodeWithRedaction(a: A): List[Option[String]] = outer.encode(a).as(Some(Encoder.RedactedText))
       override val types: List[Type] = outer.types
       override val sql: State[Int, String] = outer.sql
     }
@@ -141,6 +141,8 @@ trait Encoder[A] { outer =>
 
 /** @group Companions */
 object Encoder extends TwiddleSyntax[Encoder] {
+
+  final val RedactedText: String = "<redacted>"
 
   implicit val ContravariantSemigroupalEncoder: ContravariantSemigroupal[Encoder] =
     new ContravariantSemigroupal[Encoder] {

--- a/modules/core/shared/src/main/scala/PreparedQuery.scala
+++ b/modules/core/shared/src/main/scala/PreparedQuery.scala
@@ -57,7 +57,7 @@ trait PreparedQuery[F[_], A, B] {
 /** @group Companions */
 object PreparedQuery {
 
-  def fromProto[F[_], A, B](proto: Protocol.PreparedQuery[F, A, B])(
+  def fromProto[F[_], A, B](proto: Protocol.PreparedQuery[F, A, B], redactionStrategy: RedactionStrategy)(
     implicit ev: MonadCancel[F, Throwable]
   ): PreparedQuery[F, A, B] =
     new PreparedQuery[F, A, B] {
@@ -131,7 +131,8 @@ object PreparedQuery {
             args       = args,
             callSite   = Some(CallSite(method, or)),
             hint       = Some(h),
-            argsOrigin = Some(or)
+            argsOrigin = Some(or),
+            redactionStrategy = redactionStrategy
           )
         }
 

--- a/modules/core/shared/src/main/scala/RedactionStrategy.scala
+++ b/modules/core/shared/src/main/scala/RedactionStrategy.scala
@@ -1,0 +1,39 @@
+// Copyright (c) 2018-2021 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package skunk
+
+import skunk.data.Encoded
+
+/**
+  * Specifies how encoded values are redacted before being shown in exceptions and traces.
+  */
+sealed trait RedactionStrategy {
+  def redactArguments(arguments: List[Option[Encoded]]): List[Option[Encoded]] =
+    arguments.map(_.map(redactEncoded))
+
+  def redactEncoded(encoded: Encoded): Encoded
+}
+
+object RedactionStrategy {
+  /**
+    * Values from encoders that have explicitly enabled redaction (via `.redact`)
+    * are redacted and all other values are not.
+    * 
+    * This is the default strategy.
+    */
+  case object OptIn extends RedactionStrategy {
+    def redactEncoded(encoded: Encoded): Encoded = encoded
+  }
+
+  /** All values are redacted, regardless of what encoders specify. */
+  case object All extends RedactionStrategy {
+    def redactEncoded(encoded: Encoded): Encoded = encoded.redact
+  }
+
+  /** No values are redacted, regardless of what encoders specify. */
+  case object None extends RedactionStrategy {
+    def redactEncoded(encoded: Encoded): Encoded = encoded.unredact
+  }
+}

--- a/modules/core/shared/src/main/scala/Void.scala
+++ b/modules/core/shared/src/main/scala/Void.scala
@@ -24,7 +24,6 @@ case object Void extends Void {
   val codec: Codec[Void] =
     new Codec[Void] {
       override def encode(a: Void): List[Option[String]] = Nil
-      override def encodeWithRedaction(a: Void): List[Option[String]] = Nil
       override def decode(index: Int, ss: List[Option[String]]): Either[Decoder.Error, Void.type ] =
         ss match {
           case Nil => Void.asRight
@@ -32,6 +31,7 @@ case object Void extends Void {
         }
       override val types: List[Type] = Nil
       override val sql: State[Int, String]   = "".pure[State[Int, *]]
+      override val redact: Boolean = false
       override def toString: String = "Codec(void)"
     }
 

--- a/modules/core/shared/src/main/scala/Void.scala
+++ b/modules/core/shared/src/main/scala/Void.scala
@@ -24,6 +24,7 @@ case object Void extends Void {
   val codec: Codec[Void] =
     new Codec[Void] {
       override def encode(a: Void): List[Option[String]] = Nil
+      override def encodeWithRedaction(a: Void): List[Option[String]] = Nil
       override def decode(index: Int, ss: List[Option[String]]): Either[Decoder.Error, Void.type ] =
         ss match {
           case Nil => Void.asRight

--- a/modules/core/shared/src/main/scala/Void.scala
+++ b/modules/core/shared/src/main/scala/Void.scala
@@ -24,6 +24,7 @@ case object Void extends Void {
   val codec: Codec[Void] =
     new Codec[Void] {
       override def encode(a: Void): List[Option[String]] = Nil
+      override def encodeWithRedaction(a: Void): List[Option[String]] = Nil
       override def decode(index: Int, ss: List[Option[String]]): Either[Decoder.Error, Void.type ] =
         ss match {
           case Nil => Void.asRight
@@ -31,7 +32,6 @@ case object Void extends Void {
         }
       override val types: List[Type] = Nil
       override val sql: State[Int, String]   = "".pure[State[Int, *]]
-      override val redact: Boolean = false
       override def toString: String = "Codec(void)"
     }
 

--- a/modules/core/shared/src/main/scala/Void.scala
+++ b/modules/core/shared/src/main/scala/Void.scala
@@ -4,7 +4,7 @@
 
 package skunk
 
-import skunk.data.Type
+import skunk.data.{Encoded, Type}
 import cats.data.State
 import cats.syntax.all._
 import cats.Eq
@@ -23,8 +23,7 @@ case object Void extends Void {
 
   val codec: Codec[Void] =
     new Codec[Void] {
-      override def encode(a: Void): List[Option[String]] = Nil
-      override def encodeWithRedaction(a: Void): List[Option[String]] = Nil
+      override def encode(a: Void): List[Option[Encoded]] = Nil
       override def decode(index: Int, ss: List[Option[String]]): Either[Decoder.Error, Void.type ] =
         ss match {
           case Nil => Void.asRight

--- a/modules/core/shared/src/main/scala/data/Encoded.scala
+++ b/modules/core/shared/src/main/scala/data/Encoded.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2018-2021 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package skunk.data
+
+import cats.kernel.Eq
+
+final case class Encoded(value: String, redacted: Boolean) {
+  def redact: Encoded = if (redacted) this else Encoded(value, true)
+  override def toString: String = if (redacted) Encoded.RedactedText else value
+}
+
+object Encoded {
+  def apply(value: String): Encoded = Encoded(value, false)
+
+  final val RedactedText: String = "<redacted>"
+
+  implicit val eqInstance: Eq[Encoded] = Eq.fromUniversalEquals[Encoded]
+}

--- a/modules/core/shared/src/main/scala/data/Encoded.scala
+++ b/modules/core/shared/src/main/scala/data/Encoded.scala
@@ -15,7 +15,7 @@ final case class Encoded(value: String, redacted: Boolean) {
 object Encoded {
   def apply(value: String): Encoded = Encoded(value, false)
 
-  final val RedactedText: String = "<redacted>"
+  final val RedactedText: String = "?"
 
   implicit val eqInstance: Eq[Encoded] = Eq.fromUniversalEquals[Encoded]
 }

--- a/modules/core/shared/src/main/scala/data/Encoded.scala
+++ b/modules/core/shared/src/main/scala/data/Encoded.scala
@@ -8,6 +8,7 @@ import cats.kernel.Eq
 
 final case class Encoded(value: String, redacted: Boolean) {
   def redact: Encoded = if (redacted) this else Encoded(value, true)
+  def unredact: Encoded = if (!redacted) this else Encoded(value, false)
   override def toString: String = if (redacted) Encoded.RedactedText else value
 }
 

--- a/modules/core/shared/src/main/scala/exception/DecodeException.scala
+++ b/modules/core/shared/src/main/scala/exception/DecodeException.scala
@@ -28,7 +28,7 @@ class DecodeException[F[_], A, B](
   sql             = Some(sql),
   message         = "Decoding error.",
   detail          = Some("This query's decoder was unable to decode a row of data."),
-  arguments       = encoder.types.zip(encoder.encodeWithRedaction(arguments)),
+  arguments       = encoder.types.zip(encoder.encode(arguments)),
   argumentsOrigin = argumentsOrigin,
   sqlOrigin       = sqlOrigin
 ) {

--- a/modules/core/shared/src/main/scala/exception/DecodeException.scala
+++ b/modules/core/shared/src/main/scala/exception/DecodeException.scala
@@ -28,7 +28,7 @@ class DecodeException[F[_], A, B](
   sql             = Some(sql),
   message         = "Decoding error.",
   detail          = Some("This query's decoder was unable to decode a row of data."),
-  arguments       = encoder.types.zip(encoder.encode(arguments)),
+  arguments       = encoder.types.zip(encoder.encodeWithRedaction(arguments)),
   argumentsOrigin = argumentsOrigin,
   sqlOrigin       = sqlOrigin
 ) {

--- a/modules/core/shared/src/main/scala/exception/DecodeException.scala
+++ b/modules/core/shared/src/main/scala/exception/DecodeException.scala
@@ -5,7 +5,7 @@
 package skunk.exception
 
 import cats.syntax.all._
-import skunk.{ Encoder, Decoder }
+import skunk.{ Encoder, Decoder, RedactionStrategy }
 import skunk.util.Origin
 // import skunk.net.Protocol
 import skunk.util.Text
@@ -23,12 +23,13 @@ class DecodeException[F[_], A, B](
   argumentsOrigin: Option[Origin],
   encoder:   Encoder[A],
   rowDescription: TypedRowDescription,
-  cause:     Option[Throwable] = None
+  cause:     Option[Throwable] = None,
+  redactionStrategy: RedactionStrategy,
 ) extends SkunkException(
   sql             = Some(sql),
   message         = "Decoding error.",
   detail          = Some("This query's decoder was unable to decode a row of data."),
-  arguments       = encoder.types.zip(encoder.encode(arguments)),
+  arguments       = encoder.types.zip(redactionStrategy.redactArguments(encoder.encode(arguments))),
   argumentsOrigin = argumentsOrigin,
   sqlOrigin       = sqlOrigin
 ) {

--- a/modules/core/shared/src/main/scala/exception/PostgresErrorException.scala
+++ b/modules/core/shared/src/main/scala/exception/PostgresErrorException.scala
@@ -7,7 +7,7 @@ package skunk.exception
 import cats.syntax.all._
 import org.typelevel.otel4s.Attribute
 import skunk.SqlState
-import skunk.data.Type
+import skunk.data.{Encoded, Type}
 import skunk.util.Origin
 
 // TODO: turn this into an ADT of structured error types
@@ -16,7 +16,7 @@ class PostgresErrorException (
   sqlOrigin:       Option[Origin],
   info:            Map[Char, String],
   history:         List[Either[Any, Any]],
-  arguments:       List[(Type, Option[String])] = Nil,
+  arguments:       List[(Type, Option[Encoded])] = Nil,
   argumentsOrigin: Option[Origin]               = None
 ) extends SkunkException(
   sql       = Some(sql),
@@ -176,7 +176,7 @@ object PostgresErrorException {
     sqlOrigin:       Option[Origin],
     info:            Map[Char, String],
     history:         List[Either[Any, Any]],
-    arguments:       List[(Type, Option[String])] = Nil,
+    arguments:       List[(Type, Option[Encoded])] = Nil,
     argumentsOrigin: Option[Origin]               = None
   )(
     implicit ev: cats.MonadError[F, Throwable]

--- a/modules/core/shared/src/main/scala/exception/SkunkException.scala
+++ b/modules/core/shared/src/main/scala/exception/SkunkException.scala
@@ -143,7 +143,7 @@ object SkunkException {
       sqlOrigin       = Some(query.origin),
       callSite        = callSite,
       hint            = hint,
-      arguments       = query.encoder.types zip query.encoder.encode(args),
+      arguments       = query.encoder.types zip query.encoder.encodeWithRedaction(args),
       argumentsOrigin = argsOrigin
     )
 

--- a/modules/core/shared/src/main/scala/exception/SkunkException.scala
+++ b/modules/core/shared/src/main/scala/exception/SkunkException.scala
@@ -6,21 +6,21 @@ package skunk.exception
 
 import cats.syntax.all._
 import org.typelevel.otel4s.Attribute
-import skunk.data.Type
+import skunk.data.{Encoded, Type}
 import skunk.Query
 import skunk.util.{ CallSite, Origin, Pretty }
 
 class SkunkException protected[skunk](
   val sql:             Option[String],
   val message:         String,
-  val position:        Option[Int]                  = None,
-  val detail:          Option[String]               = None,
-  val hint:            Option[String]               = None,
-  val history:         List[Either[Any, Any]]       = Nil,
-  val arguments:       List[(Type, Option[String])] = Nil,
-  val sqlOrigin:       Option[Origin]               = None,
-  val argumentsOrigin: Option[Origin]               = None,
-  val callSite:        Option[CallSite]             = None
+  val position:        Option[Int]                   = None,
+  val detail:          Option[String]                = None,
+  val hint:            Option[String]                = None,
+  val history:         List[Either[Any, Any]]        = Nil,
+  val arguments:       List[(Type, Option[Encoded])] = Nil,
+  val sqlOrigin:       Option[Origin]                = None,
+  val argumentsOrigin: Option[Origin]                = None,
+  val callSite:        Option[CallSite]              = None
 ) extends Exception(message)  {
 
   def fields: List[Attribute[_]] = {
@@ -36,7 +36,7 @@ class SkunkException protected[skunk](
 
     (arguments.zipWithIndex).foreach { case ((typ, os), n) =>
       builder += Attribute(s"error.argument.${n + 1}.type"  , typ.name)
-      builder += Attribute(s"error.argument.${n + 1}.value" , os.getOrElse[String]("NULL"))
+      builder += Attribute(s"error.argument.${n + 1}.value" , os.map(_.toString).getOrElse[String]("NULL"))
     }
 
     sqlOrigin.foreach { o =>
@@ -103,7 +103,7 @@ class SkunkException protected[skunk](
 
   protected def args: String = {
 
-    def formatValue(s: String) =
+    def formatValue(s: Encoded) =
       s"${Console.GREEN}$s${Console.RESET}"
 
     if (arguments.isEmpty) "" else
@@ -143,7 +143,7 @@ object SkunkException {
       sqlOrigin       = Some(query.origin),
       callSite        = callSite,
       hint            = hint,
-      arguments       = query.encoder.types zip query.encoder.encodeWithRedaction(args),
+      arguments       = query.encoder.types zip query.encoder.encode(args),
       argumentsOrigin = argsOrigin
     )
 

--- a/modules/core/shared/src/main/scala/net/BitVectorSocket.scala
+++ b/modules/core/shared/src/main/scala/net/BitVectorSocket.scala
@@ -73,7 +73,7 @@ object BitVectorSocket {
     sg:            SocketGroup[F],
     socketOptions: List[SocketOption],
     sslOptions:    Option[SSLNegotiation.Options[F]],
-    readTimeout:  Duration
+    readTimeout:   Duration
   )(implicit ev: Temporal[F]): Resource[F, BitVectorSocket[F]] = {
 
     def fail[A](msg: String): Resource[F, A] =

--- a/modules/core/shared/src/main/scala/net/Protocol.scala
+++ b/modules/core/shared/src/main/scala/net/Protocol.scala
@@ -9,7 +9,7 @@ import cats.effect.{ Concurrent, Temporal, Resource }
 import cats.effect.std.Console
 import fs2.concurrent.Signal
 import fs2.Stream
-import skunk.{ Command, Query, Statement, ~, Void }
+import skunk.{ Command, Query, Statement, ~, Void, RedactionStrategy }
 import skunk.data._
 import skunk.util.{ Namer, Origin }
 import skunk.util.Typer
@@ -186,6 +186,7 @@ object Protocol {
     val preparedQuery:   PreparedQuery[F, A, B],
     val arguments:       A,
     val argumentsOrigin: Origin,
+    val redactionStrategy: RedactionStrategy
   ) extends Portal[F, A] {
     def preparedStatement: PreparedStatement[F, A] = preparedQuery
     def execute(maxRows: Int): F[List[B] ~ Boolean]
@@ -206,18 +207,20 @@ object Protocol {
     sslOptions:   Option[SSLNegotiation.Options[F]],
     describeCache: Describe.Cache[F],
     parseCache: Parse.Cache[F],
-    readTimeout:  Duration
+    readTimeout:  Duration,
+    redactionStrategy: RedactionStrategy
   ): Resource[F, Protocol[F]] =
     for {
       bms <- BufferedMessageSocket[F](host, port, 256, debug, sg, socketOptions, sslOptions, readTimeout) // TODO: should we expose the queue size?
-      p   <- Resource.eval(fromMessageSocket(bms, nam, describeCache, parseCache))
+      p   <- Resource.eval(fromMessageSocket(bms, nam, describeCache, parseCache, redactionStrategy))
     } yield p
 
   def fromMessageSocket[F[_]: Concurrent: Tracer](
     bms: BufferedMessageSocket[F],
     nam: Namer[F],
     dc:  Describe.Cache[F],
-    pc:  Parse.Cache[F]
+    pc:  Parse.Cache[F],
+    redactionStrategy: RedactionStrategy
   ): F[Protocol[F]] =
     Exchange[F].map { ex =>
       new Protocol[F] {
@@ -235,16 +238,16 @@ object Protocol {
           bms.parameters
 
         override def prepare[A](command: Command[A], ty: Typer): F[PreparedCommand[F, A]] =
-          protocol.Prepare[F](describeCache, parseCache).apply(command, ty)
+          protocol.Prepare[F](describeCache, parseCache, redactionStrategy).apply(command, ty)
 
         override def prepare[A, B](query: Query[A, B], ty: Typer): F[PreparedQuery[F, A, B]] =
-          protocol.Prepare[F](describeCache, parseCache).apply(query, ty)
+          protocol.Prepare[F](describeCache, parseCache, redactionStrategy).apply(query, ty)
 
         override def execute(command: Command[Void]): F[Completion] =
-          protocol.Query[F].apply(command)
+          protocol.Query[F](redactionStrategy).apply(command)
 
         override def execute[B](query: Query[Void, B], ty: Typer): F[List[B]] =
-          protocol.Query[F].apply(query, ty)
+          protocol.Query[F](redactionStrategy).apply(query, ty)
 
         override def startup(user: String, database: String, password: Option[String], parameters: Map[String, String]): F[Unit] =
           protocol.Startup[F].apply(user, database, password, parameters)

--- a/modules/core/shared/src/main/scala/net/protocol/Bind.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Bind.scala
@@ -43,7 +43,7 @@ object Bind {
             for {
               pn <- nextName("portal").map(PortalId(_))
               ea  = statement.statement.encoder.encode(args) // encoded args
-              ear  = statement.statement.encoder.encodeWithRedaction(args)
+              ear = statement.statement.encoder.encodeWithRedaction(args)
               _  <- span.addAttributes(
                 Attribute("arguments", ear.map(_.orNull).mkString(",")),
                 Attribute("portal-id", pn.value)

--- a/modules/core/shared/src/main/scala/net/protocol/Bind.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Bind.scala
@@ -62,7 +62,7 @@ object Bind {
                                   sqlOrigin       = Some(statement.statement.origin),
                                   info            = info,
                                   history         = hi,
-                                  arguments       = statement.statement.encoder.types.zip(statement.statement.encoder.encodeWithRedaction(args)),
+                                  arguments       = statement.statement.encoder.types.zip(ear),
                                   argumentsOrigin = Some(argsOrigin)
                                 )
                         } yield a

--- a/modules/core/shared/src/main/scala/net/protocol/Bind.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Bind.scala
@@ -43,8 +43,9 @@ object Bind {
             for {
               pn <- nextName("portal").map(PortalId(_))
               ea  = statement.statement.encoder.encode(args) // encoded args
+              ear  = statement.statement.encoder.encodeWithRedaction(args)
               _  <- span.addAttributes(
-                Attribute("arguments", ea.map(_.orNull).mkString(",")),
+                Attribute("arguments", ear.map(_.orNull).mkString(",")),
                 Attribute("portal-id", pn.value)
               )
               _  <- send(BindMessage(pn.value, statement.id.value, ea))

--- a/modules/core/shared/src/main/scala/net/protocol/Bind.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Bind.scala
@@ -61,7 +61,7 @@ object Bind {
                                   sqlOrigin       = Some(statement.statement.origin),
                                   info            = info,
                                   history         = hi,
-                                  arguments       = statement.statement.encoder.types.zip(ea),
+                                  arguments       = statement.statement.encoder.types.zip(statement.statement.encoder.encodeWithRedaction(args)),
                                   argumentsOrigin = Some(argsOrigin)
                                 )
                         } yield a

--- a/modules/core/shared/src/main/scala/net/protocol/Bind.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Bind.scala
@@ -13,15 +13,16 @@ import skunk.net.MessageSocket
 import skunk.net.Protocol.{ PreparedStatement, PortalId }
 import skunk.util.{ Origin, Namer }
 import org.typelevel.otel4s.Attribute
-import org.typelevel.otel4s.trace.Span
-import org.typelevel.otel4s.trace.Tracer
+import org.typelevel.otel4s.trace.{Span, Tracer}
+import skunk.RedactionStrategy
 
 trait Bind[F[_]] {
 
   def apply[A](
     statement:  PreparedStatement[F, A],
     args:       A,
-    argsOrigin: Origin
+    argsOrigin: Origin,
+    redactionStrategy: RedactionStrategy
   ): Resource[F, PortalId]
 
 }
@@ -36,7 +37,8 @@ object Bind {
       override def apply[A](
         statement:  PreparedStatement[F, A],
         args:       A,
-        argsOrigin: Origin
+        argsOrigin: Origin,
+        redactionStrategy: RedactionStrategy
       ): Resource[F, PortalId] =
         Resource.make {
           exchange("bind") { (span: Span[F]) =>
@@ -44,7 +46,7 @@ object Bind {
               pn <- nextName("portal").map(PortalId(_))
               ea  = statement.statement.encoder.encode(args) // encoded args
               _  <- span.addAttributes(
-                Attribute("arguments", ea.map(_.orNull).mkString(",")),
+                Attribute("arguments", redactionStrategy.redactArguments(ea).map(_.orNull).mkString(",")),
                 Attribute("portal-id", pn.value)
               )
               _  <- send(BindMessage(pn.value, statement.id.value, ea.map(_.map(_.value))))

--- a/modules/core/shared/src/main/scala/net/protocol/Execute.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Execute.scala
@@ -67,7 +67,7 @@ object Execute {
                           sqlOrigin       = Some(portal.preparedCommand.command.origin),
                           info            = info,
                           history         = hi,
-                          arguments       = portal.preparedCommand.command.encoder.types.zip(portal.preparedCommand.command.encoder.encodeWithRedaction(portal.arguments)),
+                          arguments       = portal.preparedCommand.command.encoder.types.zip(portal.preparedCommand.command.encoder.encode(portal.arguments)),
                           argumentsOrigin = Some(portal.argumentsOrigin)
                         ).raiseError[F, Completion]
                 } yield a

--- a/modules/core/shared/src/main/scala/net/protocol/Execute.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Execute.scala
@@ -67,7 +67,7 @@ object Execute {
                           sqlOrigin       = Some(portal.preparedCommand.command.origin),
                           info            = info,
                           history         = hi,
-                          arguments       = portal.preparedCommand.command.encoder.types.zip(portal.preparedCommand.command.encoder.encode(portal.arguments)),
+                          arguments       = portal.preparedCommand.command.encoder.types.zip(portal.preparedCommand.command.encoder.encodeWithRedaction(portal.arguments)),
                           argumentsOrigin = Some(portal.argumentsOrigin)
                         ).raiseError[F, Completion]
                 } yield a

--- a/modules/core/shared/src/main/scala/net/protocol/Prepare.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Prepare.scala
@@ -52,7 +52,7 @@ object Prepare {
             Bind[F].apply(this, args, origin, redactionStrategy).map {
               new QueryPortal[F, A, B](_, pq, args, origin, redactionStrategy) {
                 def execute(maxRows: Int): F[List[B] ~ Boolean] =
-                  Execute[F](redactionStrategy).apply(this, maxRows, ty)
+                  Execute[F](this.redactionStrategy).apply(this, maxRows, ty)
               }
             }
         }

--- a/modules/core/shared/src/main/scala/net/protocol/Query.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Query.scala
@@ -6,7 +6,7 @@ package skunk.net.protocol
 
 import cats.MonadError
 import cats.syntax.all._
-import skunk.{ Command, Void }
+import skunk.{ Command, Void, RedactionStrategy }
 import skunk.data.Completion
 import skunk.exception._
 import skunk.net.message.{ Query => QueryMessage, _ }
@@ -27,7 +27,7 @@ trait Query[F[_]] {
 
 object Query {
 
-  def apply[F[_]: Exchange: MessageSocket: Tracer](
+  def apply[F[_]: Exchange: MessageSocket: Tracer](redactionStrategy: RedactionStrategy)(
     implicit ev: MonadError[F, Throwable]
   ): Query[F] =
     new Unroll[F] with Query[F] {
@@ -97,6 +97,7 @@ object Query {
                       encoder        = Void.codec,
                       rowDescription = td,
                       decoder        = query.decoder,
+                      redactionStrategy = redactionStrategy
                     ).map(_._1) <* finishUp(query)
                   } else {
                     discard(query) *> ColumnAlignmentException(query, td).raiseError[F, List[B]]

--- a/modules/core/shared/src/main/scala/net/protocol/Unroll.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Unroll.scala
@@ -63,7 +63,7 @@ private[protocol] class Unroll[F[_]: MessageSocket: Tracer](
           sqlOrigin       = Some(sqlOrigin),
           info            = info,
           history         = hi,
-          arguments       = encoder.types.zip(encoder.encodeWithRedaction(args)),
+          arguments       = encoder.types.zip(encoder.encode(args)),
           argumentsOrigin = argsOrigin
         ).raiseError[F, (List[List[Option[String]]], Boolean)]
       }

--- a/modules/core/shared/src/main/scala/net/protocol/Unroll.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Unroll.scala
@@ -63,7 +63,7 @@ private[protocol] class Unroll[F[_]: MessageSocket: Tracer](
           sqlOrigin       = Some(sqlOrigin),
           info            = info,
           history         = hi,
-          arguments       = encoder.types.zip(encoder.encode(args)),
+          arguments       = encoder.types.zip(encoder.encodeWithRedaction(args)),
           argumentsOrigin = argsOrigin
         ).raiseError[F, (List[List[Option[String]]], Boolean)]
       }

--- a/modules/docs/src/main/laika/reference/Encoders.md
+++ b/modules/docs/src/main/laika/reference/Encoders.md
@@ -109,3 +109,8 @@ val person = (varchar *: int4).values.to[Person]
 sql"INSERT INTO person (name, age) VALUES $person"
 ```
 
+## Redaction
+
+By default, encoded values appear in exceptions and traces, which greatly enhances debugging. Some values are sensitive and should never be included in logs. The `Encoder` type has a `redacted` combinator which returns a new encoder of the same type, ensuring encoded values are not included in exceptions or traces.
+
+Alternatively, value redaction can be globally configured on a session level, overriding encoder level redaction settings. The default strategy is `RedactionStrategy.OptIn` which respects encoder level redaction. There's also `RedactionStrategy.All`, which redacts *all* values, and `RedactionStrategy.None`, which redacts no value. In both the all and none cases, encoder level redaction is ignored. The redaction strategy is specified as a parameter on the `Session` constructor -- e.g., `Session.single` and `Session.pooled`.

--- a/modules/tests/js/src/main/scala/ffstest/FFrameworkPlatform.scala
+++ b/modules/tests/js/src/main/scala/ffstest/FFrameworkPlatform.scala
@@ -4,6 +4,10 @@
 
 package ffstest
 
+import cats.effect.IO
 import munit.CatsEffectSuite
+import org.typelevel.otel4s.trace.Tracer
 
-trait FTestPlatform extends CatsEffectSuite
+trait FTestPlatform extends CatsEffectSuite {
+  implicit lazy val ioTracer: Tracer[IO] = Tracer.noop
+}

--- a/modules/tests/jvm/src/main/scala/ffstest/FFrameworkPlatform.scala
+++ b/modules/tests/jvm/src/main/scala/ffstest/FFrameworkPlatform.scala
@@ -4,6 +4,31 @@
 
 package ffstest
 
+import cats.effect.{IO, Resource}
 import munit.CatsEffectSuite
+import io.opentelemetry.api.GlobalOpenTelemetry
+import org.typelevel.otel4s.java.OtelJava
+import org.typelevel.otel4s.trace.Tracer
 
-trait FTestPlatform extends CatsEffectSuite
+trait FTestPlatform extends CatsEffectSuite {
+  def tracerResource: Resource[IO, Tracer[IO]] = 
+    Resource.eval(IO(GlobalOpenTelemetry.get()))
+      .evalMap(OtelJava.forAsync(_))
+      .evalMap(_.tracerProvider.get(getClass.getName()))
+
+  private var ioTracerFinalizer: IO[Unit] = _
+
+  implicit lazy val ioTracer: Tracer[IO] = {
+    val tracerAndFinalizer = tracerResource.allocated.unsafeRunSync()
+    ioTracerFinalizer = tracerAndFinalizer._2
+    tracerAndFinalizer._1
+  }
+
+  override def afterAll(): Unit = {
+    if (ioTracerFinalizer ne null) {
+      ioTracerFinalizer.unsafeRunSync()
+      ioTracerFinalizer = null
+    }
+    super.afterAll()
+  }
+}

--- a/modules/tests/jvm/src/test/scala/issue/231.scala
+++ b/modules/tests/jvm/src/test/scala/issue/231.scala
@@ -33,7 +33,7 @@ class Test231 extends FTest {
 
   test("timestamptz formatter is independent of Locale") {
     inColombia {
-      assertEqual("timestamptz", timestamptz.encode(ts).head.get, "2020-01-01 12:30:00+06 AD")
+      assertEqual("timestamptz", timestamptz.encode(ts).head.get.value, "2020-01-01 12:30:00+06 AD")
     }
   }
 

--- a/modules/tests/native/src/main/scala/ffstest/FFrameworkPlatform.scala
+++ b/modules/tests/native/src/main/scala/ffstest/FFrameworkPlatform.scala
@@ -4,9 +4,12 @@
 
 package ffstest
 
+import cats.effect.IO
 import epollcat.unsafe.EpollRuntime
 import munit.CatsEffectSuite
+import org.typelevel.otel4s.trace.Tracer
 
 trait FTestPlatform extends CatsEffectSuite {
   override def munitIORuntime = EpollRuntime.global
+  implicit lazy val ioTracer: Tracer[IO] = Tracer.noop
 }

--- a/modules/tests/shared/src/test/scala/DescribeCacheTest.scala
+++ b/modules/tests/shared/src/test/scala/DescribeCacheTest.scala
@@ -25,7 +25,7 @@ class DescribeCacheTest extends SkunkTest {
     }
   }
 
-  test("describe cache should be not shared across sessions from different pools") {
+  tracedTest("describe cache should be not shared across sessions from different pools") {
     (pooled(), pooled()).tupled.use { case (p1, p2) =>
       p1.use { s1 =>
         p2.use { s2 =>

--- a/modules/tests/shared/src/test/scala/DescribeCacheTest.scala
+++ b/modules/tests/shared/src/test/scala/DescribeCacheTest.scala
@@ -9,41 +9,24 @@ import skunk.codec.numeric.int4
 import cats.syntax.all._
 import cats.effect.IO
 import skunk.exception.PostgresErrorException
-import cats.effect.Resource
-import skunk.Session
-import org.typelevel.otel4s.trace.Tracer
 
 class DescribeCacheTest extends SkunkTest {
-
-  implicit val tracer: Tracer[IO] = Tracer.noop
 
   // N.B. this checks that statements are cached, but it _doesn't_ check that the cache is observed
   // by the `Describe` protocol implementation. There's not an easy way to do this without exposing
   // a bunch of internals.
 
-  def poolResource: Resource[IO, Resource[IO, Session[IO]]] =
-    Session.pooled(
-      host     = "localhost",
-      port     = 5432,
-      user     = "jimmy",
-      database = "world",
-      password = Some("banana"),
-      max      = 3,
-    )
-
-  test("describe cache should be shared across sessions from the same pool") {
-    poolResource.use { p =>
-      p.use { s1 =>
-        p.use { s2 =>
-          assert("sessions should be different", s1 ne s2) *>
-          assert("caches should be eq", s1.describeCache eq s2.describeCache)
-        }
+  pooledTest("describe cache should be shared across sessions from the same pool") { p =>
+    p.use { s1 =>
+      p.use { s2 =>
+        assert("sessions should be different", s1 ne s2) *>
+        assert("caches should be eq", s1.describeCache eq s2.describeCache)
       }
     }
   }
 
   test("describe cache should be not shared across sessions from different pools") {
-    (poolResource, poolResource).tupled.use { case (p1, p2) =>
+    (pooled(), pooled()).tupled.use { case (p1, p2) =>
       p1.use { s1 =>
         p2.use { s2 =>
           assert("sessions should be different", s1 ne s2) *>

--- a/modules/tests/shared/src/test/scala/DisconnectTest.scala
+++ b/modules/tests/shared/src/test/scala/DisconnectTest.scala
@@ -6,35 +6,16 @@ package tests
 
 import skunk.implicits._
 import skunk.codec.all._
-import cats.effect._
-import skunk.Session
-import org.typelevel.otel4s.trace.Tracer
 import skunk.exception.EofException
-import ffstest.FTest
 
-class DisconnectTest extends FTest {
+class DisconnectTest extends SkunkTest {
 
-  implicit val tracer: Tracer[IO] = Tracer.noop
-
-  val pool: Resource[IO, Resource[IO, Session[IO]]] =
-    Session.pooled(
-      host     = "localhost",
-      port     = 5432,
-      user     = "jimmy",
-      database = "world",
-      password = Some("banana"),
-      max      = 1, // ensure that the session is reused if possible
-      // debug = true,
-    )
-
-  test("disconnect/reconnect") {
-    pool.use { p =>
-      p.use { s => // this session will be invalidated
-        s.execute(sql"select pg_terminate_backend(pg_backend_pid())".query(bool))
-      }.assertFailsWith[EofException] *>
-      p.use { s => // this should be a *new* session, since the old one was busted
-        s.execute(sql"select 1".query(int4))
-      }
+  pooledTest("disconnect/reconnect", max = 1) { p =>
+    p.use { s => // this session will be invalidated
+      s.execute(sql"select pg_terminate_backend(pg_backend_pid())".query(bool))
+    }.assertFailsWith[EofException] *>
+    p.use { s => // this should be a *new* session, since the old one was busted
+      s.execute(sql"select 1".query(int4))
     }
   }
 

--- a/modules/tests/shared/src/test/scala/QueryTest.scala
+++ b/modules/tests/shared/src/test/scala/QueryTest.scala
@@ -107,7 +107,7 @@ class QueryTest extends SkunkTest {
     }
 
 
-    pooledTest("timeout", 2.seconds) { getS =>
+    pooledTest("timeout", readTimeout = 2.seconds) { getS =>
       val f = sql"select pg_sleep($int4)"
       def getErr[X]: Either[Throwable, X] => Option[String] = _.swap.toOption.collect {
         case e: java.util.concurrent.TimeoutException => e.getMessage()

--- a/modules/tests/shared/src/test/scala/RedshiftTest.scala
+++ b/modules/tests/shared/src/test/scala/RedshiftTest.scala
@@ -11,11 +11,9 @@ import org.typelevel.otel4s.trace.Tracer
 
 class RedshiftTest extends ffstest.FTest {
 
-  implicit val tracer: Tracer[IO] = Tracer.noop
-
   object X86ArchOnly extends munit.Tag("X86ArchOnly")
 
-  test("redshift - successfully connect".tag(X86ArchOnly)) {
+  tracedTest("redshift - successfully connect".tag(X86ArchOnly)) {
     Session.single[IO](
       host = "localhost",
       user = "postgres",
@@ -26,7 +24,7 @@ class RedshiftTest extends ffstest.FTest {
     ).use(_ => IO.unit)
   }
 
-  test("redshift - cannot connect with default params".tag(X86ArchOnly)) {
+  tracedTest("redshift - cannot connect with default params".tag(X86ArchOnly)) {
     Session.single[IO](
       host = "localhost",
       user = "postgres",

--- a/modules/tests/shared/src/test/scala/RedshiftTest.scala
+++ b/modules/tests/shared/src/test/scala/RedshiftTest.scala
@@ -7,7 +7,6 @@ package tests
 import cats.effect._
 import skunk._
 import skunk.exception.StartupException
-import org.typelevel.otel4s.trace.Tracer
 
 class RedshiftTest extends ffstest.FTest {
 

--- a/modules/tests/shared/src/test/scala/SslTest.scala
+++ b/modules/tests/shared/src/test/scala/SslTest.scala
@@ -6,12 +6,9 @@ package tests
 
 import cats.effect._
 import fs2.io.net.tls.SSLException
-import org.typelevel.otel4s.trace.Tracer
 import skunk._
 
 class SslTest extends ffstest.FTest {
-
-  implicit val tracer: Tracer[IO] = Tracer.noop
 
   object Port {
     val Invalid = 5431
@@ -19,7 +16,7 @@ class SslTest extends ffstest.FTest {
     val Trust   = 5433
   }
 
-  test("successful login with SSL.Trusted (ssl available)") {
+  tracedTest("successful login with SSL.Trusted (ssl available)") {
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -29,7 +26,7 @@ class SslTest extends ffstest.FTest {
     ).use(_ => IO.unit)
   }
 
-  test("successful login with SSL.None (ssl available)") {
+  tracedTest("successful login with SSL.None (ssl available)") {
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -39,7 +36,7 @@ class SslTest extends ffstest.FTest {
     ).use(_ => IO.unit)
   }
 
-  test("failed login with SSL.System (ssl available)") {
+  tracedTest("failed login with SSL.System (ssl available)") {
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -50,7 +47,7 @@ class SslTest extends ffstest.FTest {
     ).use(_ => IO.unit).assertFailsWith[SSLException].as("sigh") // TODO! Better failure!
   }
 
-  test("failed login with SSL.Trusted (ssl not available)") {
+  tracedTest("failed login with SSL.Trusted (ssl not available)") {
     Session.single[IO](
       host     = "localhost",
       user     = "postgres",
@@ -60,7 +57,7 @@ class SslTest extends ffstest.FTest {
     ).use(_ => IO.unit).assertFailsWith[Exception].as("ok") // TODO! Better failure!
   }
 
-  test("successful login with SSL.Trusted.withFallback(true) (ssl not available)") {
+  tracedTest("successful login with SSL.Trusted.withFallback(true) (ssl not available)") {
     Session.single[IO](
       host     = "localhost",
       user     = "postgres",
@@ -70,7 +67,7 @@ class SslTest extends ffstest.FTest {
     ).use(_ => IO.unit)
   }
 
-  test("successful login with SSL.None (ssl not available)") {
+  tracedTest("successful login with SSL.None (ssl not available)") {
     Session.single[IO](
       host     = "localhost",
       user     = "postgres",
@@ -80,7 +77,7 @@ class SslTest extends ffstest.FTest {
     ).use(_ => IO.unit)
   }
 
-  test("SSL.None cannot produce an SSLContext") {
+  tracedTest("SSL.None cannot produce an SSLContext") {
     for {
       ex <- SSL.None.tlsContext[IO].use_.assertFailsWith[Exception]
       _  <- assertEqual("failure message", ex.getMessage, "SSL.None: cannot create a TLSContext.")

--- a/modules/tests/shared/src/test/scala/StartupTest.scala
+++ b/modules/tests/shared/src/test/scala/StartupTest.scala
@@ -7,14 +7,11 @@ package tests
 import cats.effect._
 import com.comcast.ip4s.UnknownHostException
 import fs2.io.net.ConnectException
-import org.typelevel.otel4s.trace.Tracer
 import skunk._
 import skunk.exception.SkunkException
 import skunk.exception.StartupException
 
 class StartupTest extends ffstest.FTest {
-
-  implicit val tracer: Tracer[IO] = Tracer.noop
 
   // Different ports for different authentication schemes.
   object Port {
@@ -25,7 +22,7 @@ class StartupTest extends ffstest.FTest {
     val Password = 5435
   }
 
-  test("md5 - successful login") {
+  tracedTest("md5 - successful login") {
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -35,7 +32,7 @@ class StartupTest extends ffstest.FTest {
     ).use(_ => IO.unit)
   }
 
-  test("md5 - non-existent database") {
+  tracedTest("md5 - non-existent database") {
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -47,7 +44,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("code", e.code, "3D000"))
   }
 
-  test("md5 - missing password") {
+  tracedTest("md5 - missing password") {
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -59,7 +56,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("message", e.message, "Password required."))
   }
 
-  test("md5 - incorrect user") {
+  tracedTest("md5 - incorrect user") {
     Session.single[IO](
       host     = "localhost",
       user     = "frank",
@@ -71,7 +68,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("code", e.code, "28P01"))
   }
 
-  test("md5 - incorrect password") {
+  tracedTest("md5 - incorrect password") {
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -83,7 +80,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("code", e.code, "28P01"))
   }
 
-  test("trust - successful login") {
+  tracedTest("trust - successful login") {
     Session.single[IO](
       host     = "localhost",
       user     = "postgres",
@@ -93,7 +90,7 @@ class StartupTest extends ffstest.FTest {
   }
 
   // TODO: should this be an error?
-  test("trust - successful login, ignored password") {
+  tracedTest("trust - successful login, ignored password") {
     Session.single[IO](
       host     = "localhost",
       user     = "postgres",
@@ -103,7 +100,7 @@ class StartupTest extends ffstest.FTest {
     ).use(_ => IO.unit)
   }
 
-  test("trust - non-existent database") {
+  tracedTest("trust - non-existent database") {
     Session.single[IO](
       host     = "localhost",
       user     = "postgres",
@@ -114,7 +111,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("code", e.code, "3D000"))
   }
 
-  test("trust - incorrect user") {
+  tracedTest("trust - incorrect user") {
     Session.single[IO](
       host     = "localhost",
       user     = "bogus",
@@ -125,7 +122,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("code", e.code, "28000"))
   }
 
-  test("scram - successful login") {
+  tracedTest("scram - successful login") {
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -135,7 +132,7 @@ class StartupTest extends ffstest.FTest {
     ).use(_ => IO.unit)
   }
 
-  test("scram - non-existent database") {
+  tracedTest("scram - non-existent database") {
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -147,7 +144,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("code", e.code, "3D000"))
   }
 
-  test("scram - missing password") {
+  tracedTest("scram - missing password") {
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -159,7 +156,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("message", e.message, "Password required."))
   }
 
-  test("scram - incorrect user") {
+  tracedTest("scram - incorrect user") {
     Session.single[IO](
       host     = "localhost",
       user     = "frank",
@@ -171,7 +168,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("code", e.code, "28P01"))
   }
 
-  test("scram - incorrect password") {
+  tracedTest("scram - incorrect password") {
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -183,7 +180,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("code", e.code, "28P01"))
   }
 
-  test("password - successful login") {
+  tracedTest("password - successful login") {
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -193,7 +190,7 @@ class StartupTest extends ffstest.FTest {
     ).use(_ => IO.unit)
   }
 
-  test("password - non-existent database") {
+  tracedTest("password - non-existent database") {
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -205,7 +202,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("code", e.code, "3D000"))
   }
 
-  test("password - missing password") {
+  tracedTest("password - missing password") {
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -217,7 +214,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("message", e.message, "Password required."))
   }
 
-  test("password - incorrect user") {
+  tracedTest("password - incorrect user") {
     Session.single[IO](
       host     = "localhost",
       user     = "frank",
@@ -229,7 +226,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("code", e.code, "28P01"))
   }
 
-  test("password - incorrect password") {
+  tracedTest("password - incorrect password") {
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -241,7 +238,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("code", e.code, "28P01"))
   }
 
-  test("invalid port") {
+  tracedTest("invalid port") {
     Session.single[IO](
       host     = "localhost",
       user     = "bob",
@@ -250,7 +247,7 @@ class StartupTest extends ffstest.FTest {
     ).use(_ => IO.unit).assertFailsWith[ConnectException]
   }
 
-  test("invalid host") {
+  tracedTest("invalid host") {
     Session.single[IO](
       host     = "blergh",
       user     = "bob",

--- a/modules/tests/shared/src/test/scala/codec/CodecTest.scala
+++ b/modules/tests/shared/src/test/scala/codec/CodecTest.scala
@@ -31,10 +31,10 @@ abstract class CodecTest(
   def roundtripTest[A: Eq](codec: Codec[A])(as: A*): Unit = {
 
     // required for parametrized types
-    val sqlString: Fragment[A] = (codec.types match {
+    val sqlString: Fragment[A] = codec.types match {
       case head :: Nil => sql"select $codec::#${head.name}"
       case _           => sql"select $codec"
-    }).asInstanceOf[Fragment[A]] // macro doesn't quite work in dotty yet
+    }
 
     sessionTest(s"${codec.types.mkString(", ")}") { s =>
       s.prepare(sqlString.query(codec)).flatMap { ps =>

--- a/modules/tests/shared/src/test/scala/codec/EncoderTest.scala
+++ b/modules/tests/shared/src/test/scala/codec/EncoderTest.scala
@@ -38,4 +38,41 @@ class EncoderTest extends SkunkTest {
     assertEqual("data", data, Nil)
   }
 
+  val Redacted = Some(Encoder.RedactedText)
+
+  test("redaction - unredacted") {
+    val data = int4.encodeWithRedaction(42)
+    assertEquals(data, List(Some("42")))
+  }
+
+  test("redaction - redacted") {
+    val data = int4.redacted.encodeWithRedaction(42)
+    assertEquals(data, List(Redacted))
+  }
+
+  test("redaction - redacted product") {
+    val data = (int4 ~ int4).redacted.encodeWithRedaction((1, 2))
+    assertEquals(data, List(Redacted, Redacted))
+  }
+
+  test("redaction - product of redacted") {
+    val data = (int4 ~ int4.redacted).encodeWithRedaction((1, 2))
+    assertEquals(data, List(Some("1"), Redacted))
+  }
+
+  test("redaction - contramap") {
+    val data = (int4 ~ int4.redacted).contramap(identity[(Int, Int)]).encodeWithRedaction((1, 2))
+    assertEquals(data, List(Some("1"), Redacted))
+  }
+
+  test("redaction - imap") {
+    val data = (int4 ~ int4.redacted).imap(identity)(identity).encodeWithRedaction((1, 2))
+    assertEquals(data, List(Some("1"), Redacted))
+  }
+
+  test("redaction - to") {
+    case class Point(x: Int, y: Int)
+    val data = (int4 *: int4.redacted).to[Point].encodeWithRedaction(Point(1, 2))
+    assertEquals(data, List(Some("1"), Redacted))
+  }
 }

--- a/modules/tests/shared/src/test/scala/issue/210.scala
+++ b/modules/tests/shared/src/test/scala/issue/210.scala
@@ -65,7 +65,7 @@ class Test210 extends SkunkTest {
       } yield ()
     }
 
-  test("issue/210") {
+  tracedTest("issue/210") {
     for {
       ready <- Deferred[IO, Unit]
       done  <- Deferred[IO, Unit]

--- a/modules/tests/shared/src/test/scala/issue/238.scala
+++ b/modules/tests/shared/src/test/scala/issue/238.scala
@@ -6,14 +6,10 @@ package tests.issue
 
 import cats.effect._
 import skunk._
-import org.typelevel.otel4s.trace.Tracer
 
 class Test238 extends ffstest.FTest {
 
-  implicit val tracer: Tracer[IO] = Tracer.noop
-
-
-  test("see (https://github.com/functional-streams-for-scala/fs2/pull/1989)") {
+  tracedTest("see (https://github.com/functional-streams-for-scala/fs2/pull/1989)") {
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",

--- a/modules/tests/shared/src/test/scala/simulation/SimTest.scala
+++ b/modules/tests/shared/src/test/scala/simulation/SimTest.scala
@@ -10,7 +10,7 @@ import cats.effect._
 import ffstest.FTest
 import fs2.concurrent.Signal
 import org.typelevel.otel4s.trace.Tracer
-import skunk.Session
+import skunk.{Session, RedactionStrategy}
 import skunk.data.Notification
 import skunk.data.TransactionStatus
 import skunk.net._
@@ -46,9 +46,9 @@ trait SimTest extends FTest with SimMessageSocket.DSL {
       nam <- Namer[IO]
       dc  <- Describe.Cache.empty[IO](1024, 1024)
       pc  <- Parse.Cache.empty[IO](1024)
-      pro <- Protocol.fromMessageSocket(bms, nam, dc, pc)
+      pro <- Protocol.fromMessageSocket(bms, nam, dc, pc, RedactionStrategy.None)
       _   <- pro.startup(user, database, password, Session.DefaultConnectionParameters)
-      ses <- Session.fromProtocol(pro, nam, Typer.Strategy.BuiltinsOnly)
+      ses <- Session.fromProtocol(pro, nam, Typer.Strategy.BuiltinsOnly, RedactionStrategy.None)
     } yield ses
 
   def simTest[A](name: String, sim: Simulator, user: String = "Bob", database: String = "db", password: Option[String] = None)(f: Session[IO] => IO[A]): Unit =


### PR DESCRIPTION
Adds support for both encoder level redaction (e.g., `int4.redacted ~ int4`) as well as session level overrides (via `redactionStrategy = RedactionStrategy.All` or `RedactionStrategy.None`).

Some libraries default to redacting all encoded values but in this PR, we default to respecting individual encoder redaction.

This PR also updates the test infrastructure to trace all database tests (using a new top level span per test).