### PR TITLE
Add test case that exhibits portal does not exist problem.

### DIFF
--- a/world/world.sql
+++ b/world/world.sql
@@ -7,6 +7,11 @@
 
 CREATE TYPE myenum AS ENUM ('foo', 'bar');
 
+CREATE TABLE IF NOT EXISTS scalars(
+    a_string varchar not null,
+    a_int integer not null
+);
+
 CREATE TABLE IF NOT EXISTS city (
     id integer NOT NULL,
     name varchar NOT NULL,


### PR DESCRIPTION
In trying to track down the "portal does not exist" problem #553, I was able to create a test case that demonstrates the issue.

My code had a weird construction of .map(effect).flatMap(identity) instead of flatMap(effect).  I was able to reliably reproduce the bug in my code with the former and was never able to reproduce with the latter.  I was able to replicate this in Skunk code.

- flatMap(effect) no issue
- map(effect).flatMap(identity) inside of resource acquisition, no issue
- map(effect) with flatMap(identity) outside of resource acquisition, portal not found
- map(effect) with flatten outside of resource acquisition, portal not found

