### PR TITLE
Don't re-raise errors from transaction `use`

### DIFF
--- a/modules/core/shared/src/main/scala/Transaction.scala
+++ b/modules/core/shared/src/main/scala/Transaction.scala
@@ -192,7 +192,7 @@ object Transaction {
         case Failed =>
           ec match {
             // This is the normal failure case
-            case Errored(t)  => doRollback
+            case Errored(_)  => doRollback.void
             // This is possible if you swallow an error
             case Succeeded => doRollback.void
             // This is possible if you swallow an error and the someone cancels the fiber
@@ -205,7 +205,7 @@ object Transaction {
             // If someone cancels the fiber we roll back
             case Canceled  => doRollback.void
             // If an error escapes we roll back
-            case Errored(t)  => doRollback
+            case Errored(_)  => doRollback.void
           }
       }
 

--- a/modules/core/shared/src/main/scala/Transaction.scala
+++ b/modules/core/shared/src/main/scala/Transaction.scala
@@ -192,7 +192,7 @@ object Transaction {
         case Failed =>
           ec match {
             // This is the normal failure case
-            case Errored(t)  => doRollback *> t.raiseError[F, Unit]
+            case Errored(t)  => doRollback
             // This is possible if you swallow an error
             case Succeeded => doRollback.void
             // This is possible if you swallow an error and the someone cancels the fiber
@@ -205,7 +205,7 @@ object Transaction {
             // If someone cancels the fiber we roll back
             case Canceled  => doRollback.void
             // If an error escapes we roll back
-            case Errored(t)  => doRollback *> t.raiseError[F, Unit]
+            case Errored(t)  => doRollback
           }
       }
 


### PR DESCRIPTION
Fixes https://github.com/typelevel/skunk/issues/905.

Errors are already being propagated through normal channels so it should not be re-raised in a `Resource`'s release block.