### PR TITLE
Add AlterIndex completion

### DIFF
--- a/modules/core/shared/src/main/scala/data/Completion.scala
+++ b/modules/core/shared/src/main/scala/data/Completion.scala
@@ -63,6 +63,7 @@ object Completion {
   case object Explain                   extends Completion
   case object Grant                     extends Completion
   case object Revoke                    extends Completion
+  case object AlterIndex                extends Completion
   // more ...
 
   /**

--- a/modules/core/shared/src/main/scala/net/message/CommandComplete.scala
+++ b/modules/core/shared/src/main/scala/net/message/CommandComplete.scala
@@ -101,6 +101,7 @@ object CommandComplete {
     case "EXPLAIN"                    => apply(Completion.Explain)
     case "GRANT"                      => apply(Completion.Grant)
     case "REVOKE"                     => apply(Completion.Revoke)
+    case "ALTER INDEX"                => apply(Completion.AlterIndex)
     // more .. fill in as we hit them
 
     case s                  => apply(Completion.Unknown(s))

--- a/modules/tests/shared/src/test/scala/CommandTest.scala
+++ b/modules/tests/shared/src/test/scala/CommandTest.scala
@@ -143,9 +143,14 @@ class CommandTest extends SkunkTest {
       )
       """.command
 
+  val alterIndex: Command[Void] =
+    sql"""
+      ALTER INDEX IF EXISTS id_index RENAME TO pk_index
+      """.command
+
   val dropIndex: Command[Void] =
     sql"""
-      DROP INDEX id_index
+      DROP INDEX pk_index
       """.command
 
   val createView: Command[Void] =
@@ -319,16 +324,18 @@ class CommandTest extends SkunkTest {
         FROM skunk_role
        """.command
 
-  sessionTest("create table, create index, drop index, alter table and drop table") { s =>
+  sessionTest("create table, create index, alter table, alter index, drop index and drop table") { s =>
     for {
       c <- s.execute(createTable)
       _ <- assert("completion",  c == Completion.CreateTable)
       c <- s.execute(createIndex)
       _ <- assert("completion",  c == Completion.CreateIndex)
-      c <- s.execute(dropIndex)
-      _ <- assert("completion",  c == Completion.DropIndex)
       c <- s.execute(alterTable)
       _ <- assert("completion",  c == Completion.AlterTable)
+      c <- s.execute(alterIndex)
+      _ <- assert("completion", c == Completion.AlterIndex)
+      c <- s.execute(dropIndex)
+      _ <- assert("completion",  c == Completion.DropIndex)
       c <- s.execute(dropTable)
       _ <- assert("completion",  c == Completion.DropTable)
       _ <- s.assertHealthy


### PR DESCRIPTION
This tiny PR follows the suggestion from the `SkunkException` I received after issuing an `ALTER INDEX` command.

I tried to follow the guidelines for running the tests locally but I hit one issue:
```
==> X tests.StartupTest.invalid port 0.01s scala.scalajs.js.JavaScriptException: AggregateError
    at <jscode>.internalConnectMultiple(node:net:1111)
    at <jscode>.afterConnectMultiple(node:net:1663)
    at delay @ <jscode>.{anonymous}()(/Users/chrobasi/sdsc/code/skunk/modules/tests/js/target/scala-2.13/tests-test-fastopt/main.js:93975)
    at as @ <jscode>.{anonymous}()(/Users/chrobasi/sdsc/code/skunk/modules/tests/js/target/scala-2.13/tests-test-fastopt/main.js:246615)
    at delay @ fs2.io.internal.facade.events.EventEmitter$ops$.registerOneTimeListener$extension(/Users/chrobasi/sdsc/code/skunk/modules/tests/js/target/scala-2.13/tests-test-fastopt/main.js:7947)
    at productL @ <jscode>.{anonymous}()(/Users/chrobasi/sdsc/code/skunk/modules/tests/js/target/scala-2.13/tests-test-fastopt/main.js:93980)
    at flatMap @ <jscode>.{anonymous}()(/Users/chrobasi/sdsc/code/skunk/modules/tests/js/target/scala-2.13/tests-test-fastopt/main.js:90305)
    at async @ <jscode>.{anonymous}()(/Users/chrobasi/sdsc/code/skunk/modules/tests/js/target/scala-2.13/tests-test-fastopt/main.js:93964)
    at allocatedCase @ <jscode>.{anonymous}()(/Users/chrobasi/sdsc/code/skunk/modules/tests/js/target/scala-2.13/tests-test-fastopt/main.js:46843)
    at refOf @ <jscode>.{anonymous}()(/Users/chrobasi/sdsc/code/skunk/modules/tests/js/target/scala-2.13/tests-test-fastopt/main.js:43986)
    at apply @ skunk.net.protocol.Exchange$.apply(/Users/chrobasi/sdsc/code/skunk/modules/tests/js/target/scala-2.13/tests-test-fastopt/main.js:41801)
    at allocatedCase @ <jscode>.{anonymous}()(/Users/chrobasi/sdsc/code/skunk/modules/tests/js/target/scala-2.13/tests-test-fastopt/main.js:46843)
    at refOf @ <jscode>.{anonymous}()(/Users/chrobasi/sdsc/code/skunk/modules/tests/js/target/scala-2.13/tests-test-fastopt/main.js:43986)
    at allocatedCase @ <jscode>.{anonymous}()(/Users/chrobasi/sdsc/code/skunk/modules/tests/js/target/scala-2.13/tests-test-fastopt/main.js:46843)
    at onError @ <jscode>.{anonymous}()(/Users/chrobasi/sdsc/code/skunk/modules/tests/js/target/scala-2.13/tests-test-fastopt/main.js:42665)
    at make @ skunk.util.Pool$.ofF(/Users/chrobasi/sdsc/code/skunk/modules/tests/js/target/scala-2.13/tests-test-fastopt/main.js:42801)
    at make @ skunk.util.Pool$.ofF(/Users/chrobasi/sdsc/code/skunk/modules/tests/js/target/scala-2.13/tests-test-fastopt/main.js:42801)
```
Unfortunately, I'm not sure how to fix it but I've got a feeling it's probably not related to my change.