### PR TITLE
Use explicit Locale for era formatting

### DIFF
--- a/modules/core/shared/src/main/scala/codec/TemporalCodecs.scala
+++ b/modules/core/shared/src/main/scala/codec/TemporalCodecs.scala
@@ -68,7 +68,7 @@ trait TemporalCodecs {
       .toFormatter(Locale.US)
 
   private val eraFormatter: DateTimeFormatter =
-    DateTimeFormatter.ofPattern(" G")
+    DateTimeFormatter.ofPattern(" G", Locale.US)
 
   private val localDateFormatter: DateTimeFormatter =
     new DateTimeFormatterBuilder()


### PR DESCRIPTION
The field `eraFormatter` in `TemporalCodecs.scala` is missing an explicit reference to `Locale.US` which can cause unexpected behavior when a locale db with i.e. british locale is added to the dependencies.  

I encountered this because we added https://github.com/cquiroz/scala-java-locales to our project, whose default db, which is recommended in the repository, is for british english. 