### PR TITLE
Update otel4s to v0.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,7 @@ ThisBuild / mimaBinaryIssueFilters ++= List(
 // This is used in a couple places
 lazy val fs2Version = "3.9.3"
 lazy val openTelemetryVersion = "1.29.0"
-lazy val otel4sVersion = "0.3.0-RC2"
+lazy val otel4sVersion = "0.3.0"
 lazy val refinedVersion = "0.11.0"
 
 // Global Settings


### PR DESCRIPTION
Doesn't look like ScalaSteward picked it up

https://github.com/typelevel/otel4s/releases/tag/v0.3.0