### PR TITLE
Use pipelining to optimize Prepared Commands

### DIFF
--- a/modules/core/shared/src/main/scala/PreparedCommand.scala
+++ b/modules/core/shared/src/main/scala/PreparedCommand.scala
@@ -4,12 +4,11 @@
 
 package skunk
 
-import cats.{ Contravariant, ~> }
-import cats.effect.MonadCancel
+import cats.{Contravariant, ~>}
+import fs2.Pipe
 import skunk.data.Completion
 import skunk.net.Protocol
 import skunk.util.Origin
-import fs2.Pipe
 
 /**
  * A prepared command, valid for the life of its defining `Session`.
@@ -49,12 +48,10 @@ object PreparedCommand {
         }
     }
 
-  def fromProto[F[_], A](pc: Protocol.PreparedCommand[F, A])(
-    implicit ev: MonadCancel[F, Throwable]
-  ): PreparedCommand[F, A] =
+  def fromProto[F[_], A](pc: Protocol.PreparedCommand[F, A]): PreparedCommand[F, A] =
     new PreparedCommand[F, A] {
       override def execute(args: A)(implicit origin: Origin): F[Completion] =
-        pc.bind(args, origin).use(_.execute)
+        pc.bindExecute(args, origin)
     }
 
 }

--- a/modules/core/shared/src/main/scala/net/Protocol.scala
+++ b/modules/core/shared/src/main/scala/net/Protocol.scala
@@ -143,6 +143,7 @@ object Protocol {
   ) extends PreparedStatement[F, A] {
     def statement: Statement[A] = command
     def bind(args: A, argsOrigin: Origin): Resource[F, CommandPortal[F, A]]
+    def bindExecute(args: A, argsOrigin: Origin): F[Completion]
   }
 
   /**

--- a/modules/core/shared/src/main/scala/net/protocol/BindExecute.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/BindExecute.scala
@@ -1,0 +1,127 @@
+// Copyright (c) 2018-2021 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package net.protocol
+
+import cats.effect.kernel.{MonadCancelThrow, Resource}
+import cats.syntax.all.*
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.trace.{Span, Tracer}
+import skunk.RedactionStrategy
+import skunk.data.Completion
+import skunk.exception.*
+import skunk.net.Protocol.{PortalId, PreparedCommand}
+import skunk.net.{MessageSocket, message}
+import skunk.net.protocol.*
+import skunk.util.{Namer, Origin}
+
+trait BindExecute[F[_]] {
+
+  def command[A](
+                  statement: PreparedCommand[F, A],
+                  args: A,
+                  argsOrigin: Origin,
+                  redactionStrategy: RedactionStrategy): F[Completion]
+
+  //def query[A, B](
+  //                 statement: PreparedQuery[F, A, B],
+  //                 args: A,
+  //                 argsOrigin: Origin,
+  //                 redactionStrategy: RedactionStrategy,
+  //                 maxRows: Int,
+  //                 ty: Typer
+  //               ): F[List[B] ~ Boolean]
+
+}
+
+object BindExecute {
+
+  def apply[F[_] : Exchange : MessageSocket : Namer : Tracer: MonadCancelThrow]: BindExecute[F] =
+    new BindExecute[F] {
+
+      // https://github.com/tpolecat/skunk/issues/210
+      val syncReady: F[Unit] =
+        send(message.Sync) *> expect { case message.ReadyForQuery(_) => }
+
+      def command[A](
+                      statement: PreparedCommand[F, A],
+                      args: A,
+                      argsOrigin: Origin,
+                      redactionStrategy: RedactionStrategy
+                    ): F[Completion] =
+        exchange("bind_execute") { (span: Span[F]) =>
+          Resource.make(nextName("portal").map(PortalId(_)))(Close[F].apply).use { pn =>
+          val ea = statement.statement.encoder.encode(args) // encoded args
+          for {
+            _ <- span.addAttributes(
+              Attribute("arguments", redactionStrategy.redactArguments(ea).map(_.orNull).mkString(",")),
+              Attribute("portal-id", pn.value)
+            )
+            _ <- send(message.Bind(pn.value, statement.id.value, ea.map(_.map(_.value))))
+            _ <- send(message.Execute(pn.value, 0))
+            _ <- send(message.Flush)
+            _ <- flatExpect {
+              case message.BindComplete => ().pure[F]
+              case message.ErrorResponse(info) =>
+                for {
+                  hi <- history(Int.MaxValue)
+                  _ <- syncReady
+                  a <- PostgresErrorException.raiseError[F, Unit](
+                    sql = statement.statement.sql,
+                    sqlOrigin = Some(statement.statement.origin),
+                    info = info,
+                    history = hi,
+                    arguments = statement.statement.encoder.types.zip(ea),
+                    argumentsOrigin = Some(argsOrigin)
+                  )
+                } yield a
+            }
+            c <- flatExpect {
+              case skunk.net.message.CommandComplete(c) => syncReady.as(c)
+              case message.EmptyQueryResponse =>
+                syncReady *>
+                  new EmptyStatementException(statement.command).raiseError[F, Completion]
+
+              case message.CopyOutResponse(_) =>
+                receive.iterateWhile {
+                  case message.CommandComplete(_) => true
+                  case _ => false
+                } *>
+                  new CopyNotSupportedException(statement.command).raiseError[F, Completion]
+
+              case message.CopyInResponse(_) =>
+                send(message.CopyFail) *>
+                  expect { case message.ErrorResponse(_) => }
+                syncReady *>
+                  new CopyNotSupportedException(statement.command).raiseError[F, Completion]
+
+              case message.ErrorResponse(info) =>
+                for {
+                  hi <- history(Int.MaxValue)
+                  _ <- syncReady
+                  redactedArgs = statement.command.encoder.types zip redactionStrategy.redactArguments(ea)
+                  a <- PostgresErrorException.raiseError[F, Completion](
+                    sql = statement.command.sql,
+                    sqlOrigin = Some(statement.command.origin),
+                    info = info,
+                    history = hi,
+                    arguments = redactedArgs,
+                    argumentsOrigin = Some(argsOrigin)
+                  )
+                } yield a
+            }
+          } yield c
+        }}
+
+
+      //def query[A, B](
+      //           statement: PreparedQuery[F, A, B],
+      //           args: A,
+      //           argsOrigin: Origin,
+      //           redactionStrategy: RedactionStrategy,
+      //           maxRows: Int,
+      //           ty: Typer
+      //         ): F[List[B] ~ Boolean] = ???
+    }
+}


### PR DESCRIPTION
Following ideas in #605, we can reduce the number of message exchanged and speed up some part of the client-server communication.

This PR replace this exchange : 
```
> Bind
> Flush
[expect BindComplete]
< BindComplete
> Execute
> Flush
[expect CommandComplete]
< CommandComplete
> Sync 
[expect ReadyForQuery]
```
By this one : 
```
> Bind
> Execute
> Flush
[expect BindComplete]
[expect CommandComplete]
< BindComplete
< CommandComplete
> Sync 
[expect ReadyForQuery]
```