### PR TITLE
Add completions: alter role, create/alter/drop policy, comment, analyze, alter function

### DIFF
--- a/modules/core/shared/src/main/scala/data/Completion.scala
+++ b/modules/core/shared/src/main/scala/data/Completion.scala
@@ -34,6 +34,7 @@ object Completion {
   case object AlterType                 extends Completion
   case object CreateFunction            extends Completion
   case object DropFunction              extends Completion
+  case object AlterFunction             extends Completion
   case class  Copy(count: Int)          extends Completion
   case object Show                      extends Completion
   case object Do                        extends Completion
@@ -51,6 +52,7 @@ object Completion {
   case object DropDatabase              extends Completion
   case object CreateRole                extends Completion
   case object DropRole                  extends Completion
+  case object AlterRole                 extends Completion
   case object CreateMaterializedView    extends Completion
   case object RefreshMaterializedView   extends Completion
   case object DropMaterializedView      extends Completion
@@ -65,6 +67,11 @@ object Completion {
   case object Revoke                    extends Completion
   case object AlterIndex                extends Completion
   case class Merge(count: Int)          extends Completion
+  case object CreatePolicy              extends Completion
+  case object AlterPolicy               extends Completion
+  case object DropPolicy                extends Completion
+  case object Comment                   extends Completion
+  case object Analyze                   extends Completion
   // more ...
 
   /**

--- a/modules/core/shared/src/main/scala/net/message/CommandComplete.scala
+++ b/modules/core/shared/src/main/scala/net/message/CommandComplete.scala
@@ -69,6 +69,7 @@ object CommandComplete {
     case "ALTER TYPE"                 => apply(Completion.AlterType)
     case "CREATE FUNCTION"            => apply(Completion.CreateFunction)
     case "DROP FUNCTION"              => apply(Completion.DropFunction)
+    case "ALTER FUNCTION"             => apply(Completion.AlterFunction)
     case "SHOW"                       => apply(Completion.Show)
     case "DO"                         => apply(Completion.Do)
     case "CREATE PROCEDURE"           => apply(Completion.CreateProcedure)
@@ -85,6 +86,7 @@ object CommandComplete {
     case "DROP DATABASE"              => apply(Completion.DropDatabase)
     case "CREATE ROLE"                => apply(Completion.CreateRole)
     case "DROP ROLE"                  => apply(Completion.DropRole)
+    case "ALTER ROLE"                 => apply(Completion.AlterRole)
     case "CREATE MATERIALIZED VIEW"   => apply(Completion.CreateMaterializedView)
     case "REFRESH MATERIALIZED VIEW"  => apply(Completion.RefreshMaterializedView)
     case "DROP MATERIALIZED VIEW"     => apply(Completion.DropMaterializedView)
@@ -104,6 +106,11 @@ object CommandComplete {
     case "REVOKE"                     => apply(Completion.Revoke)
     case "ALTER INDEX"                => apply(Completion.AlterIndex)
     case Patterns.Merge(s)            => apply(Completion.Merge(s.toInt))
+    case "COMMENT"                    => apply(Completion.Comment)
+    case "CREATE POLICY"              => apply(Completion.CreatePolicy)
+    case "ALTER POLICY"               => apply(Completion.AlterPolicy)
+    case "DROP POLICY"                => apply(Completion.DropPolicy)
+    case "ANALYZE"                    => apply(Completion.Analyze)
     // more .. fill in as we hit them
 
     case s                  => apply(Completion.Unknown(s))

--- a/modules/tests/shared/src/test/scala/CommandTest.scala
+++ b/modules/tests/shared/src/test/scala/CommandTest.scala
@@ -242,6 +242,9 @@ class CommandTest extends SkunkTest {
         CREATE ROLE skunk_role
        """.command
 
+  val alterRole: Command[Void] =
+    sql"ALTER ROLE skunk_role WITH PASSWORD '123'".command
+
   val dropRole: Command[Void] =
     sql"""
         DROP ROLE skunk_role
@@ -295,6 +298,11 @@ class CommandTest extends SkunkTest {
         END;'
     """.command
 
+  val alterFunction: Command[Void] =
+    sql"""
+        ALTER FUNCTION my_trigger_func() RESET search_path
+    """.command
+
   val dropFunction: Command[Void] =
     sql"DROP FUNCTION my_trigger_func;".command
 
@@ -331,6 +339,35 @@ class CommandTest extends SkunkTest {
         FROM skunk_role
        """.command
 
+  val addComment : Command[Void] =
+    sql"COMMENT ON TABLE city IS 'A city'".command
+  
+  val removeComment : Command[Void] =
+    sql"COMMENT ON TABLE city IS NULL".command
+
+  val createPolicy: Command[Void] =
+    sql"""
+      CREATE POLICY my_policy ON city 
+      TO CURRENT_USER
+      WITH CHECK (FALSE)
+       """.command
+
+  val alterPolicy: Command[Void] =
+    sql"""
+      ALTER POLICY my_policy 
+      ON city TO CURRENT_USER 
+      WITH CHECK (TRUE)
+       """.command
+  
+  val dropPolicy: Command[Void] =
+    sql"DROP POLICY my_policy ON city".command
+
+  val analyze: Command[Void] =
+    sql"ANALYZE city".command
+  
+  val analyzeVerbose: Command[Void] =
+    sql"ANALYZE VERBOSE city".command
+
   sessionTest("create table, create index, alter table, alter index, drop index and drop table") { s =>
     for {
       c <- s.execute(createTable)
@@ -359,6 +396,8 @@ class CommandTest extends SkunkTest {
       _ <- assert("completion", c == Completion.AlterTrigger)
       c <- s.execute(dropTrigger)
       _ <- assert("completion",  c == Completion.DropTrigger)
+      c <- s.execute(alterFunction)
+      _ <- assert("completion",  c == Completion.AlterFunction)
       c <- s.execute(dropFunction)
       _ <- assert("completion",  c == Completion.DropFunction)
       _ <- s.assertHealthy
@@ -383,6 +422,18 @@ class CommandTest extends SkunkTest {
       _ <- assert("completion",  c == Completion.AlterType)
       c <- s.execute(dropType)
       _ <- assert("completion",  c == Completion.DropType)
+      _ <- s.assertHealthy
+    } yield "ok"
+  }
+
+  sessionTest("create, alter and drop policy") { s =>
+    for {
+      c <- s.execute(createPolicy)
+      _ <- assert("completion",  c == Completion.CreatePolicy)
+      c <- s.execute(alterPolicy)
+      _ <- assert("completion",  c == Completion.AlterPolicy)
+      c <- s.execute(dropPolicy)
+      _ <- assert("completion",  c == Completion.DropPolicy)
       _ <- s.assertHealthy
     } yield "ok"
   }
@@ -458,10 +509,12 @@ class CommandTest extends SkunkTest {
     } yield "ok"
   }
 
-  sessionTest("create role, drop role") { s =>
+  sessionTest("create role, alter role, drop role") { s =>
     for {
       c <- s.execute(createRole)
       _ <- assert("completion", c == Completion.CreateRole)
+      c <- s.execute(alterRole)
+      _ <- assert("completion", c == Completion.AlterRole)
       c <- s.execute(dropRole)
       _ <- assert("completion", c == Completion.DropRole)
     } yield "ok"
@@ -480,6 +533,26 @@ class CommandTest extends SkunkTest {
     for{
       c <- s.execute(doCommand)
       _ <- assert("completion", c == Completion.Do)
+      _ <- s.assertHealthy
+    } yield "ok"
+  }
+
+  sessionTest("add comment, remove comment") { s =>
+    for{
+      c <- s.execute(addComment)
+      _ <- assert("completion", c == Completion.Comment)
+      c <- s.execute(removeComment)
+      _ <- assert("completion", c == Completion.Comment)
+      _ <- s.assertHealthy
+    } yield "ok"
+  }
+
+  sessionTest("analyze") { s =>
+    for{
+      c <- s.execute(analyze)
+      _ <- assert("completion", c == Completion.Analyze)
+      v <- s.execute(analyzeVerbose)
+      _ <- assert("completion", v == Completion.Analyze)
       _ <- s.assertHealthy
     } yield "ok"
   }


### PR DESCRIPTION
Support for completions: 
- `ALTER ROLE`
- `CREATE POLICY` , `ALTER POLICY`, `DROP POLICY`
- `COMMENT`
- `ANALYZE`
- `ALTER FUNCTION`

(Re-targeted branch of https://github.com/typelevel/skunk/pull/1039)