### PR TITLE
Add basic select benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,7 @@ jobs:
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: skunk_2.13 skunk_3 docs_2.13 docs_3 skunk_2.13 skunk_3 skunk_2.13 skunk_3 tests_sjs1_2.13 tests_sjs1_3 tests_2.13 tests_3 example_2.13 example_3 tests_native0.4_2.13 tests_native0.4_3
+          modules-ignore: skunk_2.13 skunk_3 docs_2.13 docs_3 skunk_2.13 skunk_3 skunk_2.13 skunk_3 tests_sjs1_2.13 tests_sjs1_3 tests_2.13 tests_3 example_2.13 example_3 tests_native0.4_2.13 tests_native0.4_3 bench_2.13 bench_3
           configs-ignore: test scala-tool scala-doc-tool test-internal
 
   site:

--- a/build.sbt
+++ b/build.sbt
@@ -98,6 +98,7 @@ lazy val commonSettings = Seq(
 
 lazy val skunk = tlCrossRootProject
   .settings(name := "skunk")
+  .aggregate(bench, core, tests, circe, refined, postgis, example, unidocs)
   .aggregate(core, tests, circe, refined, postgis, example, unidocs)
   .settings(commonSettings)
 
@@ -242,6 +243,17 @@ lazy val example = project
     //   "org.http4s"    %%% "http4s-circe"        % "0.21.22",
     //   "io.circe"      %%% "circe-generic"       % "0.13.0",
     // ).filterNot(_ => scalaVersion.value.startsWith("3."))
+  )
+
+lazy val bench = project
+  .in(file("modules/bench"))
+  .enablePlugins(NoPublishPlugin)
+  .enablePlugins(AutomateHeaderPlugin)
+  .enablePlugins(JmhPlugin)
+  .dependsOn(core.jvm)
+  .settings(commonSettings)
+  .settings(
+    libraryDependencies += "org.postgresql" % "postgresql" % "42.7.2"
   )
 
 lazy val unidocs = project

--- a/modules/bench/src/main/scala/skunk/bench/SelectBench.scala
+++ b/modules/bench/src/main/scala/skunk/bench/SelectBench.scala
@@ -1,0 +1,81 @@
+// Copyright (c) 2018-2021 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package skunk.bench
+
+import cats.effect._
+import skunk._
+import skunk.implicits._
+import skunk.codec.all._
+
+import java.sql.DriverManager
+import org.openjdk.jmh.annotations._
+import org.typelevel.otel4s.trace.Tracer
+
+@State(Scope.Benchmark)
+object SelectBenchScope {
+  implicit val tracer: Tracer[IO] = Tracer.noop[IO]
+
+  val defaultChunkSize = 512
+
+  val session: Resource[IO, skunk.Session[IO]] =
+    Session.single(
+      host = "localhost",
+      user = "jimmy",
+      database = "world",
+      password = Some("banana")
+    )
+}
+
+class SelectBench {
+  import SelectBenchScope._
+  import cats.effect.unsafe.implicits.global
+
+  // Baseline hand-written JDBC code
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements","org.wartremover.warts.While"))
+  def jdbcBench(n: Int): Int = {
+    Class.forName("org.postgresql.Driver")
+    val co = DriverManager.getConnection("jdbc:postgresql:world", "jimmy", "banana")
+    try {
+      co.setAutoCommit(false)
+      val ps = co.prepareStatement("select a.name, b.name, co.name from country a, country b, country co limit ?")
+      try {
+        ps.setInt(1, n)
+        val rs = ps.executeQuery
+        try {
+          val accum = List.newBuilder[(String, String, String)]
+          while (rs.next) {
+            val a = rs.getString(1) ; rs.wasNull
+            val b = rs.getString(2) ; rs.wasNull
+            val c = rs.getString(3) ; rs.wasNull
+            accum += ((a, b, c))
+          }
+          accum.result().length
+        } finally rs.close
+      } finally ps.close
+    } finally {
+      co.commit()
+      co.close()
+    }
+  }
+
+  // Reading via .stream
+  def skunkBenchP(n: Int): Int =
+    session.use { s =>
+        val query = sql"select a.name, b.name, c.name from country a, country b, country c limit $int4".query(varchar *: varchar *: varchar)
+
+        s.prepare(query)
+          .flatMap(_.stream(n, defaultChunkSize).compile.toList)
+          .map(_.length)
+    }.unsafeRunSync()
+
+  @Benchmark
+  @OperationsPerInvocation(1000)
+  def list_accum_1000_jdbc: Int = jdbcBench(1000)
+
+  @Benchmark
+  @OperationsPerInvocation(1000)
+  def stream_accum_1000: Int = skunkBenchP(1000)
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
 addSbtPlugin("org.typelevel"             % "sbt-typelevel"      % "0.6.5")
 addSbtPlugin("org.typelevel"             % "sbt-typelevel-site" % "0.6.5")
 addSbtPlugin("com.timushev.sbt"          % "sbt-updates"        % "0.6.4")
+addSbtPlugin("pl.project13.scala"        % "sbt-jmh"            % "0.4.7")
 addSbtPlugin("org.scoverage"             % "sbt-scoverage"      % "2.0.9")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.15.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")


### PR DESCRIPTION
Hello @tpolecat,

Thank you so much for such a cool data access library. I see how much effort and time was invested in researching this topic and implementing such a wonderful tool as Skunk. Thank you :pray: 

Recently, I noticed that the Skunk repository doesn't have benchmarks. If you don't mind, can we add some basic selection tests similar to those in the Doobie repository? In case this work is relevant, we can also consider adding more tests (for example, to test DML operations). And I will be glad to help with it.

Thank you in advance!