### PR TITLE
Update otel4s to 0.5.0-RC2, use `otel4s-sdk` in tests

### DIFF
--- a/modules/example/src/main/scala/Minimal2.scala
+++ b/modules/example/src/main/scala/Minimal2.scala
@@ -10,9 +10,8 @@ import cats.syntax.all._
 import skunk._
 import skunk.implicits._
 import skunk.codec.all._
-import io.opentelemetry.api.GlobalOpenTelemetry
 import org.typelevel.otel4s.Attribute
-import org.typelevel.otel4s.java.OtelJava
+import org.typelevel.otel4s.oteljava.OtelJava
 import org.typelevel.otel4s.trace.Tracer
 import fs2.io.net.Network
 import cats.effect.std.Console
@@ -55,12 +54,9 @@ object Minimal2 extends IOApp {
       List("A%", "B%").parTraverse(p => lookup(p, s))
     } as ExitCode.Success
 
-  def getTracer[F[_]: Async: LiftIO]: Resource[F, Tracer[F]] = {
-    Resource
-      .eval(Sync[F].delay(GlobalOpenTelemetry.get))
-      .evalMap(OtelJava.forAsync[F])
+  def getTracer[F[_]: Async: LiftIO]: Resource[F, Tracer[F]] =
+    OtelJava.autoConfigured[F]()
       .evalMap(_.tracerProvider.tracer("skunk-http4s-example").get)
-  }
 
   def run(args: List[String]): IO[ExitCode] =
     getTracer[IO].use { implicit T =>

--- a/modules/tests/js/src/main/scala/ffstest/FFrameworkPlatform.scala
+++ b/modules/tests/js/src/main/scala/ffstest/FFrameworkPlatform.scala
@@ -5,9 +5,10 @@
 package ffstest
 
 import cats.effect.IO
+import fs2.compression.Compression
 import munit.CatsEffectSuite
-import org.typelevel.otel4s.trace.Tracer
 
 trait FTestPlatform extends CatsEffectSuite {
-  implicit lazy val ioTracer: Tracer[IO] = Tracer.noop
+  implicit val fs2Compression: Compression[IO] =
+    fs2.io.compression.fs2ioCompressionForIO
 }

--- a/modules/tests/jvm/src/main/scala/ffstest/FFrameworkPlatform.scala
+++ b/modules/tests/jvm/src/main/scala/ffstest/FFrameworkPlatform.scala
@@ -4,31 +4,6 @@
 
 package ffstest
 
-import cats.effect.{IO, Resource}
 import munit.CatsEffectSuite
-import io.opentelemetry.api.GlobalOpenTelemetry
-import org.typelevel.otel4s.java.OtelJava
-import org.typelevel.otel4s.trace.Tracer
 
-trait FTestPlatform extends CatsEffectSuite {
-  def tracerResource: Resource[IO, Tracer[IO]] = 
-    Resource.eval(IO(GlobalOpenTelemetry.get()))
-      .evalMap(OtelJava.forAsync(_))
-      .evalMap(_.tracerProvider.get(getClass.getName()))
-
-  private var ioTracerFinalizer: IO[Unit] = _
-
-  implicit lazy val ioTracer: Tracer[IO] = {
-    val tracerAndFinalizer = tracerResource.allocated.unsafeRunSync()
-    ioTracerFinalizer = tracerAndFinalizer._2
-    tracerAndFinalizer._1
-  }
-
-  override def afterAll(): Unit = {
-    if (ioTracerFinalizer ne null) {
-      ioTracerFinalizer.unsafeRunSync()
-      ioTracerFinalizer = null
-    }
-    super.afterAll()
-  }
-}
+trait FTestPlatform extends CatsEffectSuite

--- a/modules/tests/native/src/main/scala/ffstest/FFrameworkPlatform.scala
+++ b/modules/tests/native/src/main/scala/ffstest/FFrameworkPlatform.scala
@@ -4,12 +4,9 @@
 
 package ffstest
 
-import cats.effect.IO
 import epollcat.unsafe.EpollRuntime
 import munit.CatsEffectSuite
-import org.typelevel.otel4s.trace.Tracer
 
 trait FTestPlatform extends CatsEffectSuite {
   override def munitIORuntime = EpollRuntime.global
-  implicit lazy val ioTracer: Tracer[IO] = Tracer.noop
 }

--- a/modules/tests/shared/src/test/scala/DescribeCacheTest.scala
+++ b/modules/tests/shared/src/test/scala/DescribeCacheTest.scala
@@ -8,6 +8,7 @@ import skunk.implicits._
 import skunk.codec.numeric.int4
 import cats.syntax.all._
 import cats.effect.IO
+import org.typelevel.otel4s.trace.Tracer
 import skunk.exception.PostgresErrorException
 
 class DescribeCacheTest extends SkunkTest {
@@ -25,7 +26,7 @@ class DescribeCacheTest extends SkunkTest {
     }
   }
 
-  tracedTest("describe cache should be not shared across sessions from different pools") {
+  tracedTest("describe cache should be not shared across sessions from different pools") { implicit tracer: Tracer[IO] =>
     (pooled(), pooled()).tupled.use { case (p1, p2) =>
       p1.use { s1 =>
         p2.use { s2 =>

--- a/modules/tests/shared/src/test/scala/RedshiftTest.scala
+++ b/modules/tests/shared/src/test/scala/RedshiftTest.scala
@@ -5,6 +5,7 @@
 package tests
 
 import cats.effect._
+import org.typelevel.otel4s.trace.Tracer
 import skunk._
 import skunk.exception.StartupException
 
@@ -12,7 +13,7 @@ class RedshiftTest extends ffstest.FTest {
 
   object X86ArchOnly extends munit.Tag("X86ArchOnly")
 
-  tracedTest("redshift - successfully connect".tag(X86ArchOnly)) {
+  tracedTest("redshift - successfully connect".tag(X86ArchOnly)) { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host = "localhost",
       user = "postgres",
@@ -23,7 +24,7 @@ class RedshiftTest extends ffstest.FTest {
     ).use(_ => IO.unit)
   }
 
-  tracedTest("redshift - cannot connect with default params".tag(X86ArchOnly)) {
+  tracedTest("redshift - cannot connect with default params".tag(X86ArchOnly)) { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host = "localhost",
       user = "postgres",

--- a/modules/tests/shared/src/test/scala/SessionTest.scala
+++ b/modules/tests/shared/src/test/scala/SessionTest.scala
@@ -5,6 +5,7 @@
 package tests
 
 import cats.effect._
+import org.typelevel.otel4s.trace.Tracer.Implicits.noop
 import skunk.Session
 import skunk.exception.SkunkException
 

--- a/modules/tests/shared/src/test/scala/SslTest.scala
+++ b/modules/tests/shared/src/test/scala/SslTest.scala
@@ -6,6 +6,7 @@ package tests
 
 import cats.effect._
 import fs2.io.net.tls.SSLException
+import org.typelevel.otel4s.trace.Tracer
 import skunk._
 
 class SslTest extends ffstest.FTest {
@@ -16,7 +17,7 @@ class SslTest extends ffstest.FTest {
     val Trust   = 5433
   }
 
-  tracedTest("successful login with SSL.Trusted (ssl available)") {
+  tracedTest("successful login with SSL.Trusted (ssl available)") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -26,7 +27,7 @@ class SslTest extends ffstest.FTest {
     ).use(_ => IO.unit)
   }
 
-  tracedTest("successful login with SSL.None (ssl available)") {
+  tracedTest("successful login with SSL.None (ssl available)") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -36,7 +37,7 @@ class SslTest extends ffstest.FTest {
     ).use(_ => IO.unit)
   }
 
-  tracedTest("failed login with SSL.System (ssl available)") {
+  tracedTest("failed login with SSL.System (ssl available)") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -47,7 +48,7 @@ class SslTest extends ffstest.FTest {
     ).use(_ => IO.unit).assertFailsWith[SSLException].as("sigh") // TODO! Better failure!
   }
 
-  tracedTest("failed login with SSL.Trusted (ssl not available)") {
+  tracedTest("failed login with SSL.Trusted (ssl not available)") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "postgres",
@@ -57,7 +58,7 @@ class SslTest extends ffstest.FTest {
     ).use(_ => IO.unit).assertFailsWith[Exception].as("ok") // TODO! Better failure!
   }
 
-  tracedTest("successful login with SSL.Trusted.withFallback(true) (ssl not available)") {
+  tracedTest("successful login with SSL.Trusted.withFallback(true) (ssl not available)") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "postgres",
@@ -67,7 +68,7 @@ class SslTest extends ffstest.FTest {
     ).use(_ => IO.unit)
   }
 
-  tracedTest("successful login with SSL.None (ssl not available)") {
+  tracedTest("successful login with SSL.None (ssl not available)") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "postgres",
@@ -77,7 +78,7 @@ class SslTest extends ffstest.FTest {
     ).use(_ => IO.unit)
   }
 
-  tracedTest("SSL.None cannot produce an SSLContext") {
+  tracedTest("SSL.None cannot produce an SSLContext") { _ =>
     for {
       ex <- SSL.None.tlsContext[IO].use_.assertFailsWith[Exception]
       _  <- assertEqual("failure message", ex.getMessage, "SSL.None: cannot create a TLSContext.")

--- a/modules/tests/shared/src/test/scala/StartupTest.scala
+++ b/modules/tests/shared/src/test/scala/StartupTest.scala
@@ -7,6 +7,7 @@ package tests
 import cats.effect._
 import com.comcast.ip4s.UnknownHostException
 import fs2.io.net.ConnectException
+import org.typelevel.otel4s.trace.Tracer
 import skunk._
 import skunk.exception.SkunkException
 import skunk.exception.StartupException
@@ -22,7 +23,7 @@ class StartupTest extends ffstest.FTest {
     val Password = 5435
   }
 
-  tracedTest("md5 - successful login") {
+  tracedTest("md5 - successful login") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -32,7 +33,7 @@ class StartupTest extends ffstest.FTest {
     ).use(_ => IO.unit)
   }
 
-  tracedTest("md5 - non-existent database") {
+  tracedTest("md5 - non-existent database") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -44,7 +45,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("code", e.code, "3D000"))
   }
 
-  tracedTest("md5 - missing password") {
+  tracedTest("md5 - missing password") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -56,7 +57,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("message", e.message, "Password required."))
   }
 
-  tracedTest("md5 - incorrect user") {
+  tracedTest("md5 - incorrect user") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "frank",
@@ -68,7 +69,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("code", e.code, "28P01"))
   }
 
-  tracedTest("md5 - incorrect password") {
+  tracedTest("md5 - incorrect password") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -80,7 +81,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("code", e.code, "28P01"))
   }
 
-  tracedTest("trust - successful login") {
+  tracedTest("trust - successful login") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "postgres",
@@ -90,7 +91,7 @@ class StartupTest extends ffstest.FTest {
   }
 
   // TODO: should this be an error?
-  tracedTest("trust - successful login, ignored password") {
+  tracedTest("trust - successful login, ignored password") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "postgres",
@@ -100,7 +101,7 @@ class StartupTest extends ffstest.FTest {
     ).use(_ => IO.unit)
   }
 
-  tracedTest("trust - non-existent database") {
+  tracedTest("trust - non-existent database") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "postgres",
@@ -111,7 +112,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("code", e.code, "3D000"))
   }
 
-  tracedTest("trust - incorrect user") {
+  tracedTest("trust - incorrect user") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "bogus",
@@ -122,7 +123,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("code", e.code, "28000"))
   }
 
-  tracedTest("scram - successful login") {
+  tracedTest("scram - successful login") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -132,7 +133,7 @@ class StartupTest extends ffstest.FTest {
     ).use(_ => IO.unit)
   }
 
-  tracedTest("scram - non-existent database") {
+  tracedTest("scram - non-existent database") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -144,7 +145,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("code", e.code, "3D000"))
   }
 
-  tracedTest("scram - missing password") {
+  tracedTest("scram - missing password") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -156,7 +157,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("message", e.message, "Password required."))
   }
 
-  tracedTest("scram - incorrect user") {
+  tracedTest("scram - incorrect user") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "frank",
@@ -168,7 +169,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("code", e.code, "28P01"))
   }
 
-  tracedTest("scram - incorrect password") {
+  tracedTest("scram - incorrect password") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -180,7 +181,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("code", e.code, "28P01"))
   }
 
-  tracedTest("password - successful login") {
+  tracedTest("password - successful login") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -190,7 +191,7 @@ class StartupTest extends ffstest.FTest {
     ).use(_ => IO.unit)
   }
 
-  tracedTest("password - non-existent database") {
+  tracedTest("password - non-existent database") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -202,7 +203,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("code", e.code, "3D000"))
   }
 
-  tracedTest("password - missing password") {
+  tracedTest("password - missing password") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -214,7 +215,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("message", e.message, "Password required."))
   }
 
-  tracedTest("password - incorrect user") {
+  tracedTest("password - incorrect user") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "frank",
@@ -226,7 +227,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("code", e.code, "28P01"))
   }
 
-  tracedTest("password - incorrect password") {
+  tracedTest("password - incorrect password") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",
@@ -238,7 +239,7 @@ class StartupTest extends ffstest.FTest {
      .flatMap(e => assertEqual("code", e.code, "28P01"))
   }
 
-  tracedTest("invalid port") {
+  tracedTest("invalid port") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "bob",
@@ -247,7 +248,7 @@ class StartupTest extends ffstest.FTest {
     ).use(_ => IO.unit).assertFailsWith[ConnectException]
   }
 
-  tracedTest("invalid host") {
+  tracedTest("invalid host") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "blergh",
       user     = "bob",

--- a/modules/tests/shared/src/test/scala/codec/TemporalCodecTest.scala
+++ b/modules/tests/shared/src/test/scala/codec/TemporalCodecTest.scala
@@ -11,6 +11,7 @@ import org.typelevel.cats.time.{ offsetdatetimeInstances => _, _ }
 import java.time._
 import skunk.codec.temporal._
 import cats.effect.{IO, Resource}
+import org.typelevel.otel4s.trace.Tracer
 import skunk._, skunk.implicits._
 import scala.concurrent.duration.{ Duration => SDuration }
 
@@ -24,7 +25,7 @@ class TemporalCodecTest extends CodecTest {
 
   // Also, run these tests with the session set to a timezone other than UTC. Our test instance is
   // set to UTC, which masks the error reported at https://github.com/tpolecat/skunk/issues/313.
-  override def session(readTimeout: SDuration): Resource[IO,Session[IO]] =
+  override def session(readTimeout: SDuration)(implicit tracer: Tracer[IO]): Resource[IO,Session[IO]] =
     super.session(readTimeout).evalTap(s => s.execute(sql"SET TIME ZONE +3".command))
 
   // Date

--- a/modules/tests/shared/src/test/scala/issue/238.scala
+++ b/modules/tests/shared/src/test/scala/issue/238.scala
@@ -5,11 +5,12 @@
 package tests.issue
 
 import cats.effect._
+import org.typelevel.otel4s.trace.Tracer
 import skunk._
 
 class Test238 extends ffstest.FTest {
 
-  tracedTest("see (https://github.com/functional-streams-for-scala/fs2/pull/1989)") {
+  tracedTest("see (https://github.com/functional-streams-for-scala/fs2/pull/1989)") { implicit tracer: Tracer[IO] =>
     Session.single[IO](
       host     = "localhost",
       user     = "jimmy",


### PR DESCRIPTION
The `otel4s-sdk-*` modules provide a cross-platform implementation of the SDK API. 

The traces seem consistent across platforms:

<details>
  <summary>JVM</summary>

![image](https://github.com/typelevel/skunk/assets/6395483/2e675336-bb60-4088-9b1e-d8e3e1aec3f2)

</details>

<details>
  <summary>JS</summary>

![image](https://github.com/typelevel/skunk/assets/6395483/693d90a1-e40b-4f60-a480-2e9571a55bab)

</details>