### PR TITLE
TCP Pipelining: Optimize Bind+Execute message flow

### DIFF
--- a/modules/core/shared/src/main/scala/PreparedQuery.scala
+++ b/modules/core/shared/src/main/scala/PreparedQuery.scala
@@ -63,7 +63,7 @@ object PreparedQuery {
     new PreparedQuery[F, A, B] {
 
      override def cursor(args: A)(implicit or: Origin): Resource[F, Cursor[F, B]] =
-        proto.bind(args, or).map { p =>
+        proto.bind(args, or, None).map { p =>
           new Cursor[F, B] {
             override def fetch(maxRows: Int): F[(List[B], Boolean)] =
               p.execute(maxRows)
@@ -71,7 +71,7 @@ object PreparedQuery {
         }
 
       override def stream(args: A, chunkSize: Int)(implicit or: Origin): Stream[F, B] =
-        Stream.resource(proto.bind(args, or)).flatMap { cursor =>
+        Stream.resource(proto.bind(args, or, Some(chunkSize))).flatMap { cursor =>
           def chunks: Stream[F, B] =
             Stream.eval(cursor.execute(chunkSize)).flatMap { case (bs, more) =>
               val s = Stream.chunk(Chunk.from(bs))
@@ -84,7 +84,7 @@ object PreparedQuery {
       // We have a few operations that only want the first row. In order to do this AND
       // know if there are more we need to ask for 2 rows.
       private def fetch2(args: A)(implicit or: Origin): F[(List[B], Boolean)] =
-        cursor(args).use(_.fetch(2))
+        proto.bind(args, or, Some(2)).use(_.execute(2))
 
       override def option(args: A)(implicit or: Origin): F[Option[B]] =
         fetch2(args).flatMap { case (bs, _) =>

--- a/modules/core/shared/src/main/scala/net/Protocol.scala
+++ b/modules/core/shared/src/main/scala/net/Protocol.scala
@@ -163,7 +163,7 @@ object Protocol {
     val rowDescription: TypedRowDescription
   ) extends PreparedStatement[F, A] {
     def statement: Statement[A] = query
-    def bind(args: A, argsOrigin: Origin): Resource[F, QueryPortal[F, A, B]]
+    def bind(args: A, argsOrigin: Origin, maxRows: Option[Int]): Resource[F, QueryPortal[F, A, B]]
   }
 
   /**

--- a/modules/core/shared/src/main/scala/net/Protocol.scala
+++ b/modules/core/shared/src/main/scala/net/Protocol.scala
@@ -163,7 +163,8 @@ object Protocol {
     val rowDescription: TypedRowDescription
   ) extends PreparedStatement[F, A] {
     def statement: Statement[A] = query
-    def bind(args: A, argsOrigin: Origin, maxRows: Option[Int]): Resource[F, QueryPortal[F, A, B]]
+    def bind(args: A, argsOrigin: Origin): Resource[F, QueryPortal[F, A, B]]
+    def bindSized(args: A, argsOrigin: Origin, maxRows: Int): Resource[F, QueryPortal[F, A, B]]
   }
 
   /**

--- a/modules/core/shared/src/main/scala/net/protocol/BindExecute.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/BindExecute.scala
@@ -6,9 +6,10 @@ package skunk.net.protocol
 
 import cats.effect.Resource
 import cats.syntax.all._
-import cats.MonadError
+import cats.effect.Concurrent
+import skunk.~
 import skunk.exception._
-import skunk.net.message.{ Bind => BindMessage, Close => _, _ }
+import skunk.net.message.{ Bind => BindMessage, Execute => ExecuteMessage, Close => _, _ }
 import skunk.net.MessageSocket
 import skunk.net.Protocol.PortalId
 import skunk.util.{ Origin, Namer }
@@ -18,6 +19,7 @@ import skunk.RedactionStrategy
 import skunk.net.Protocol
 import skunk.data.Completion
 import skunk.net.protocol.exchange
+import cats.effect.kernel.Deferred
 
 trait BindExecute[F[_]] {
 
@@ -28,21 +30,28 @@ trait BindExecute[F[_]] {
     redactionStrategy: RedactionStrategy
   ): Resource[F, Protocol.CommandPortal[F, A]]
 
+  def query[A, B](
+    statement:  Protocol.PreparedQuery[F, A, B],
+    args:       A,
+    argsOrigin: Origin,
+    redactionStrategy: RedactionStrategy,
+    initialSize: Int
+  ): Resource[F, Protocol.QueryPortal[F, A, B]]
 }
 
 object BindExecute {
   
   def apply[F[_]: Exchange: MessageSocket: Namer: Tracer](
-    implicit ev: MonadError[F, Throwable]
+    implicit ev: Concurrent[F]
   ): BindExecute[F] =
-    new BindExecute[F] {
-
-      def command[A](
-        statement:  Protocol.PreparedCommand[F, A],
-        args:       A,
+    new Unroll[F] with BindExecute[F] {
+      
+      def bindExchange[A](
+        statement: Protocol.PreparedStatement[F, A],
+        args: A,
         argsOrigin: Origin,
         redactionStrategy: RedactionStrategy
-      ): Resource[F, Protocol.CommandPortal[F, A]] = {
+      ):(Span[F] => F[PortalId], F[Unit]) = {
         val ea  = statement.statement.encoder.encode(args) // encoded args
         
         def preBind(span: Span[F]): F[PortalId] = for {
@@ -71,8 +80,17 @@ object BindExecute {
                     )
             } yield a
         }
+        (preBind, postBind)
+      }
 
-        def preExec(portal: PortalId):F[Unit] = send(Execute(portal.value, 0))
+      def command[A](
+        statement:  Protocol.PreparedCommand[F, A],
+        args:       A,
+        argsOrigin: Origin,
+        redactionStrategy: RedactionStrategy
+      ): Resource[F, Protocol.CommandPortal[F, A]] = {
+
+        val (preBind, postBind) = bindExchange(statement, args, argsOrigin, redactionStrategy)
 
         val postExec: F[Completion] = flatExpect {
           case CommandComplete(c) => send(Sync) *> expect { case ReadyForQuery(_) => c } // https://github.com/tpolecat/skunk/issues/210
@@ -118,7 +136,7 @@ object BindExecute {
           exchange("bind+execute"){ (span: Span[F]) =>
             for {
               pn <- preBind(span)
-              _  <- preExec(pn) 
+              _  <- send(ExecuteMessage(pn.value, 0))
               _  <- send(Flush)
               _  <- postBind
               c  <- postExec
@@ -128,8 +146,41 @@ object BindExecute {
           }
         } { portal => Close[F].apply(portal.id)}
 
-      }
     }
+
+      def query[A, B](
+        statement:  Protocol.PreparedQuery[F, A, B],
+        args:       A,
+        argsOrigin: Origin,
+        redactionStrategy: RedactionStrategy,
+        initialSize: Int
+      ): Resource[F, Protocol.QueryPortal[F, A, B]] = {
+        val (preBind, postBind) = bindExchange(statement, args, argsOrigin, redactionStrategy)
+        Resource.eval(Deferred[F, Unit]).flatMap { prefetch =>
+          Resource.make {
+            exchange("bind+execute"){ (span: Span[F]) =>
+              for {
+                pn <- preBind(span)
+                _  <- span.addAttributes(
+                        Attribute("max-rows",  initialSize.toLong),
+                        Attribute("portal-id", pn.value)
+                      )
+                _  <- send(ExecuteMessage(pn.value, initialSize))
+                _  <- send(Flush)
+                rs <- unroll(statement, args, argsOrigin, redactionStrategy)
+                _  <- postBind
+              } yield new Protocol.QueryPortal[F, A, B](pn, statement, args, argsOrigin, redactionStrategy) {
+                def execute(maxRows: Int): F[List[B] ~ Boolean] = 
+                  prefetch.tryGet.flatMap {
+                    case None => rs.pure <* prefetch.complete(())
+                    case Some(()) => Execute[F].apply(this, maxRows)
+                  }
+              }
+            }
+          } { portal => Close[F].apply(portal.id)}
+        }
+      }
+  }
 
 
 }

--- a/modules/core/shared/src/main/scala/net/protocol/BindExecute.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/BindExecute.scala
@@ -146,7 +146,7 @@ object BindExecute {
           }
         } { portal => Close[F].apply(portal.id)}
 
-    }
+      }
 
       def query[A, B](
         statement:  Protocol.PreparedQuery[F, A, B],
@@ -167,8 +167,8 @@ object BindExecute {
                       )
                 _  <- send(ExecuteMessage(pn.value, initialSize))
                 _  <- send(Flush)
-                rs <- unroll(statement, args, argsOrigin, redactionStrategy)
                 _  <- postBind
+                rs <- unroll(statement, args, argsOrigin, redactionStrategy)
               } yield new Protocol.QueryPortal[F, A, B](pn, statement, args, argsOrigin, redactionStrategy) {
                 def execute(maxRows: Int): F[List[B] ~ Boolean] = 
                   prefetch.tryGet.flatMap {

--- a/modules/core/shared/src/main/scala/net/protocol/BindExecute.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/BindExecute.scala
@@ -1,0 +1,136 @@
+// Copyright (c) 2018-2024 by Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package skunk.net.protocol
+
+import cats.effect.Resource
+import cats.syntax.all._
+import cats.MonadError
+import skunk.exception._
+import skunk.net.message.{ Bind => BindMessage, Close => _, _ }
+import skunk.net.MessageSocket
+import skunk.net.Protocol.PortalId
+import skunk.util.{ Origin, Namer }
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.trace.{Span, Tracer}
+import skunk.RedactionStrategy
+import skunk.net.Protocol
+import skunk.data.Completion
+import skunk.net.protocol.exchange
+import skunk.data.Encoded
+
+trait BindExecute[F[_]] {
+
+  def command[A](
+    statement:  Protocol.PreparedCommand[F, A],
+    args:       A,
+    argsOrigin: Origin,
+    redactionStrategy: RedactionStrategy
+  ): Resource[F, Protocol.CommandPortal[F, A]]
+
+}
+
+object BindExecute {
+  
+  def apply[F[_]: Exchange: MessageSocket: Namer: Tracer](
+    implicit ev: MonadError[F, Throwable]
+  ): BindExecute[F] =
+    new BindExecute[F] {
+
+      def command[A](
+        statement:  Protocol.PreparedCommand[F, A],
+        args:       A,
+        argsOrigin: Origin,
+        redactionStrategy: RedactionStrategy
+      ): Resource[F, Protocol.CommandPortal[F, A]] = {
+        
+        def preBind(span: Span[F]): F[(PortalId, List[Option[Encoded]])] = for {
+              pn <- nextName("portal").map(PortalId(_))
+              ea  = statement.statement.encoder.encode(args) // encoded args
+              _  <- span.addAttributes(
+                Attribute("arguments", redactionStrategy.redactArguments(ea).map(_.orNull).mkString(",")),
+                Attribute("portal-id", pn.value)
+              )
+              _  <- send(BindMessage(pn.value, statement.id.value, ea.map(_.map(_.value))))
+        } yield (pn, ea)
+
+        def postBind(ea: List[Option[Encoded]]):F[Unit] = flatExpect {
+          case BindComplete        => ().pure[F]
+          case ErrorResponse(info) =>
+            for {
+              hi <- history(Int.MaxValue)
+              _  <- send(Sync)
+              _  <- expect { case ReadyForQuery(_) => }
+              a  <- PostgresErrorException.raiseError[F, Unit](
+                      sql             = statement.statement.sql,
+                      sqlOrigin       = Some(statement.statement.origin),
+                      info            = info,
+                      history         = hi,
+                      arguments       = statement.statement.encoder.types.zip(ea),
+                      argumentsOrigin = Some(argsOrigin)
+                    )
+            } yield a
+        }
+
+        def preExec(portal: PortalId):F[Unit] = send(Execute(portal.value, 0))
+
+        val postExec: F[Completion] = flatExpect {
+          case CommandComplete(c) => send(Sync) *> expect { case ReadyForQuery(_) => c } // https://github.com/tpolecat/skunk/issues/210
+
+          case EmptyQueryResponse =>
+            send(Sync) *>
+            expect { case ReadyForQuery(_) => } *>
+            new EmptyStatementException(statement.command).raiseError[F, Completion]
+
+          case CopyOutResponse(_) =>
+            receive.iterateUntil {
+              case CommandComplete(_) => true
+              case _                  => false
+            } *>
+            new CopyNotSupportedException(statement.command).raiseError[F, Completion]
+
+          case CopyInResponse(_) =>
+            send(CopyFail) *>
+            expect { case ErrorResponse(_) => } *>
+            send(Sync) *>
+            expect { case ReadyForQuery(_) => } *>
+            new CopyNotSupportedException(statement.command).raiseError[F, Completion]
+
+          case ErrorResponse(info) =>
+            for {
+              hi <- history(Int.MaxValue)
+              _  <- send(Sync)
+              _  <- expect { case ReadyForQuery(_) => }
+              redactedArgs = statement.command.encoder.types.zip(
+                redactionStrategy.redactArguments(statement.command.encoder.encode(args)))
+              a  <- new PostgresErrorException(
+                      sql             = statement.command.sql,
+                      sqlOrigin       = Some(statement.command.origin),
+                      info            = info,
+                      history         = hi,
+                      arguments       = redactedArgs,
+                      argumentsOrigin = Some(argsOrigin)
+                    ).raiseError[F, Completion]
+            } yield a
+        }
+
+        Resource.make {
+          exchange("bind+execute"){ (span: Span[F]) =>
+            for {
+              (pn, ea) <- preBind(span)
+              _        <- preExec(pn) 
+              _        <- send(Flush)
+              _        <- postBind(ea)
+              c        <- postExec
+            } yield new Protocol.CommandPortal[F, A](pn, statement, args, argsOrigin) {
+              def execute: F[Completion] = c.pure
+            }
+          }
+        } { portal => Close[F].apply(portal.id)}
+
+      }
+    }
+
+
+}

--- a/modules/core/shared/src/main/scala/net/protocol/Execute.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Execute.scala
@@ -9,13 +9,12 @@ import cats.MonadError
 import skunk.~
 import skunk.net.{ Protocol, MessageSocket }
 import skunk.net.message.{ Execute => ExecuteMessage, _ }
-import skunk.util.Typer
 import org.typelevel.otel4s.Attribute
 import org.typelevel.otel4s.trace.Span
 import org.typelevel.otel4s.trace.Tracer
 
 trait Execute[F[_]] {
-  def apply[A, B](portal: Protocol.QueryPortal[F, A, B], maxRows: Int, ty: Typer): F[List[B] ~ Boolean]
+  def apply[A, B](portal: Protocol.QueryPortal[F, A, B], maxRows: Int): F[List[B] ~ Boolean]
 }
 
 object Execute {
@@ -25,7 +24,7 @@ object Execute {
   ): Execute[F] =
     new Unroll[F] with Execute[F] {
 
-      override def apply[A, B](portal: Protocol.QueryPortal[F, A, B], maxRows: Int, ty: Typer): F[List[B] ~ Boolean] =
+      override def apply[A, B](portal: Protocol.QueryPortal[F, A, B], maxRows: Int): F[List[B] ~ Boolean] =
         exchange("execute") { (span: Span[F]) =>
           for {
             _  <- span.addAttributes(

--- a/modules/core/shared/src/main/scala/net/protocol/Execute.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Execute.scala
@@ -6,76 +6,24 @@ package skunk.net.protocol
 
 import cats.syntax.all._
 import cats.MonadError
-import skunk.{~, RedactionStrategy}
-import skunk.data.Completion
-import skunk.exception.PostgresErrorException
+import skunk.~
 import skunk.net.{ Protocol, MessageSocket }
 import skunk.net.message.{ Execute => ExecuteMessage, _ }
 import skunk.util.Typer
 import org.typelevel.otel4s.Attribute
 import org.typelevel.otel4s.trace.Span
 import org.typelevel.otel4s.trace.Tracer
-import skunk.exception.CopyNotSupportedException
-import skunk.exception.EmptyStatementException
 
 trait Execute[F[_]] {
-  def apply[A](portal: Protocol.CommandPortal[F, A]): F[Completion]
   def apply[A, B](portal: Protocol.QueryPortal[F, A, B], maxRows: Int, ty: Typer): F[List[B] ~ Boolean]
 }
 
 object Execute {
 
-  def apply[F[_]: Exchange: MessageSocket: Tracer](redactionStrategy: RedactionStrategy)(
+  def apply[F[_]: Exchange: MessageSocket: Tracer](
     implicit ev: MonadError[F, Throwable]
   ): Execute[F] =
     new Unroll[F] with Execute[F] {
-
-      override def apply[A](portal: Protocol.CommandPortal[F, A]): F[Completion] =
-        exchange("execute") { (_: Span[F]) =>
-          for {
-            _  <- send(ExecuteMessage(portal.id.value, 0))
-            _  <- send(Flush)
-            c  <- flatExpect {
-              case CommandComplete(c) => send(Sync) *> expect { case ReadyForQuery(_) => c } // https://github.com/tpolecat/skunk/issues/210
-
-              case EmptyQueryResponse =>
-                send(Sync) *>
-                expect { case ReadyForQuery(_) => } *>
-                new EmptyStatementException(portal.preparedCommand.command).raiseError[F, Completion]
-
-              case CopyOutResponse(_) =>
-                receive.iterateUntil {
-                  case CommandComplete(_) => true
-                  case _                  => false
-                } *>
-                new CopyNotSupportedException(portal.preparedCommand.command).raiseError[F, Completion]
-
-              case CopyInResponse(_) =>
-                send(CopyFail) *>
-                expect { case ErrorResponse(_) => } *>
-                send(Sync) *>
-                expect { case ReadyForQuery(_) => } *>
-                new CopyNotSupportedException(portal.preparedCommand.command).raiseError[F, Completion]
-
-              case ErrorResponse(info) =>
-                for {
-                  hi <- history(Int.MaxValue)
-                  _  <- send(Sync)
-                  _  <- expect { case ReadyForQuery(_) => }
-                  redactedArgs = portal.preparedCommand.command.encoder.types.zip(
-                    redactionStrategy.redactArguments(portal.preparedCommand.command.encoder.encode(portal.arguments)))
-                  a  <- new PostgresErrorException(
-                          sql             = portal.preparedCommand.command.sql,
-                          sqlOrigin       = Some(portal.preparedCommand.command.origin),
-                          info            = info,
-                          history         = hi,
-                          arguments       = redactedArgs,
-                          argumentsOrigin = Some(portal.argumentsOrigin)
-                        ).raiseError[F, Completion]
-                } yield a
-            }
-          } yield c
-        }
 
       override def apply[A, B](portal: Protocol.QueryPortal[F, A, B], maxRows: Int, ty: Typer): F[List[B] ~ Boolean] =
         exchange("execute") { (span: Span[F]) =>

--- a/modules/core/shared/src/main/scala/net/protocol/ParseDescribe.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/ParseDescribe.scala
@@ -21,7 +21,7 @@ import skunk.util.Namer
 import skunk.net.protocol.exchange
 
 trait ParseDescribe[F[_]] {
-  def apply[A](cmd: skunk.Command[A], ty: Typer): F[StatementId]
+  def command[A](cmd: skunk.Command[A], ty: Typer): F[StatementId]
   def apply[A, B](query: skunk.Query[A, B], ty: Typer): F[(StatementId, TypedRowDescription)]
 }
 
@@ -77,11 +77,11 @@ object ParseDescribe {
 
         }
 
-      override def apply[A](cmd: skunk.Command[A], ty: Typer): F[StatementId] = {
+      override def command[A](cmd: skunk.Command[A], ty: Typer): F[StatementId] = {
 
         def describeExchange(span: Span[F]): F[(StatementId => F[Unit], F[Unit])] = 
           OptionT(cache.commandCache.get(cmd)).as(((_: StatementId) => ().pure, ().pure)).getOrElse {
-            val pre = (id: StatementId) =>for {
+            val pre = (id: StatementId) => for {
               _  <- span.addAttribute(Attribute("statement-id", id.value))
               _  <- send(DescribeMessage.statement(id.value))
             } yield ()

--- a/modules/core/shared/src/main/scala/net/protocol/Prepare.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Prepare.scala
@@ -42,7 +42,7 @@ object Prepare {
               Bind[F].apply(this, args, origin, redactionStrategy).map {
                new QueryPortal[F, A, B](_, pq, args, origin, redactionStrategy) {
                   def execute(maxRows: Int): F[List[B] ~ Boolean] =
-                   Execute[F](this.redactionStrategy).apply(this, maxRows, ty)
+                   Execute[F].apply(this, maxRows, ty)
                }
              }
           }

--- a/modules/core/shared/src/main/scala/net/protocol/Unroll.scala
+++ b/modules/core/shared/src/main/scala/net/protocol/Unroll.scala
@@ -11,6 +11,7 @@ import skunk.exception.DecodeException
 import skunk.net.message._
 import skunk.net.MessageSocket
 import skunk.net.Protocol.QueryPortal
+import skunk.net.Protocol.PreparedQuery
 import skunk.util.Origin
 import skunk.data.TypedRowDescription
 import org.typelevel.otel4s.Attribute
@@ -40,6 +41,24 @@ private[protocol] class Unroll[F[_]: MessageSocket: Tracer](
       rowDescription = portal.preparedQuery.rowDescription,
       decoder        = portal.preparedQuery.query.decoder,
       redactionStrategy = portal.redactionStrategy
+    )
+  
+  def unroll[A, B](
+    preparedQuery: PreparedQuery[F, A, B],
+    arguments: A,
+    argumentsOrigin: Origin,
+    redactionStrategy: RedactionStrategy
+  ): F[(List[B], Boolean)] =
+    unroll(
+      extended       = true,
+      sql            = preparedQuery.query.sql,
+      sqlOrigin      = preparedQuery.query.origin,
+      args           = arguments,
+      argsOrigin     = Some(argumentsOrigin),
+      encoder        = preparedQuery.query.encoder,
+      rowDescription = preparedQuery.rowDescription,
+      decoder        = preparedQuery.query.decoder,
+      redactionStrategy = redactionStrategy
     )
 
   // When we do a quick query there's no statement to hang onto all the error-reporting context


### PR DESCRIPTION
Another pipelining optim query, this time on the Command `bind` + `execute` combo.

Expect a good performance bump when using short-lived command or queries

**Commands**
Before : 
`Bind -> Flush -> await BindComplete -> Execute -> Flush -> await CommandComplete`
After : 
`Bind -> Execute -> Flush -> await BindComplete ->  await CommandComplete`

**Queries with a fixed known size (unique, option, stream)**
Before
* portal creation `Bind -> Flush -> await BindComplete`
* call to execute method `Execute -> Flush -> Unroll`

After:
* portal creation `Bind -> Execute -> Flush -> await BindComplete ->  Unroll and retain the value`
* call to execute method
  * First time : Lookup and use the cached value
  * Following : `Execute -> Flush -> Unroll`

**Queries with an unknown size (cursors)**
No changes