### PR TITLE
Fix #1042 - deadlock in session pool

### DIFF
--- a/bin/local
+++ b/bin/local
@@ -28,4 +28,4 @@ esac
 export SERVER_KEY=$(cat world/server.key)
 export SERVER_CERT=$(cat world/server.crt)
 
-docker compose $CMD $EXTRA_FLAGS
+docker-compose $CMD $EXTRA_FLAGS

--- a/modules/core/shared/src/main/scala/util/Pool.scala
+++ b/modules/core/shared/src/main/scala/util/Pool.scala
@@ -152,7 +152,7 @@ object Pool {
           ref.modify {
             case (os, Nil) =>  ((os :+ None, Nil), ().pure[F]) // new empty slot
             case (os, d :: ds) =>  ((os, ds), Concurrent[F].attempt(rsrc(Tracer[F]).allocated).flatMap(d.complete).void) // alloc now!
-          } .guarantee(a._2).flatten
+          }.flatten.guarantee(a._2)
         }
 
       // Hey, that's all we need to create our resource!

--- a/modules/core/shared/src/main/scala/util/Pool.scala
+++ b/modules/core/shared/src/main/scala/util/Pool.scala
@@ -152,7 +152,7 @@ object Pool {
           ref.modify {
             case (os, Nil) =>  ((os :+ None, Nil), ().pure[F]) // new empty slot
             case (os, d :: ds) =>  ((os, ds), Concurrent[F].attempt(rsrc(Tracer[F]).allocated).flatMap(d.complete).void) // alloc now!
-          }.flatten.guarantee(a._2)
+          }.flatMap(next => a._2.guarantee(next)) // first finalize the original alloc then potentially do new alloc
         }
 
       // Hey, that's all we need to create our resource!

--- a/modules/tests/shared/src/test/scala/PoolTest.scala
+++ b/modules/tests/shared/src/test/scala/PoolTest.scala
@@ -83,7 +83,7 @@ class PoolTest extends FTest {
     }
   }
 
-  tracedTest("error in finalizer does not prevent cleanup of deferreds".only) { implicit tracer: Tracer[IO] =>
+  tracedTest("error in finalizer does not prevent cleanup of deferreds") { implicit tracer: Tracer[IO] =>
     val r = Resource.make(IO(1))(_ => IO.raiseError(ResetFailure()))
     val p = Pool.ofF({(_: Tracer[IO]) => r}, 1)(Recycler.failure)
     p.use { r =>


### PR DESCRIPTION
Fixes #1042. Issue occurred when (a) allocated resource failed to be returned to the pool and (b) resource finalizer also failed with an error.