### PR TITLE
Use Host instead of Hostname for Session creation

### DIFF
--- a/modules/core/shared/src/main/scala/net/BitVectorSocket.scala
+++ b/modules/core/shared/src/main/scala/net/BitVectorSocket.scala
@@ -80,7 +80,7 @@ object BitVectorSocket {
       Resource.eval(ev.raiseError(new SkunkException(message = msg, sql = None)))
 
     def sock: Resource[F, Socket[F]] = {
-      (Hostname.fromString(host), Port.fromInt(port)) match {
+      (Host.fromString(host), Port.fromInt(port)) match {
         case (Some(validHost), Some(validPort)) => sg.client(SocketAddress(validHost, validPort), socketOptions)
         case (None, _) =>  fail(s"""Hostname: "$host" is not syntactically valid.""")
         case (_, None) =>  fail(s"Port: $port falls out of the allowed range.")


### PR DESCRIPTION
Hostname is not capable of parsing IPV6 addresses:

```scala
scala> Hostname.fromString("127.0.0.1")
val res0: Option[com.comcast.ip4s.Hostname] = Some(127.0.0.1)

scala> Host.fromString("127.0.0.1")
val res1: Option[com.comcast.ip4s.Host] = Some(127.0.0.1)

scala> res1.map(_.getClass.getName)
val res2: Option[String] = Some(com.comcast.ip4s.Ipv4Address)

scala> Hostname.fromString("::1")
val res0: Option[com.comcast.ip4s.Hostname] = None

scala> Host.fromString("::1")
val res1: Option[com.comcast.ip4s.Host] = Some(::1)
```

(repl sessh courtesy of @mpilquist )