### PR TITLE
Fix the 'submit-dependency' job in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,7 +299,7 @@ jobs:
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: skunk_2.12 skunk_2.13 skunk_3 docs_2.12 docs_2.13 docs_3 skunk_2.12 skunk_2.13 skunk_3 skunk_2.12 skunk_2.13 skunk_3 tests_sjs1_2.12 tests_sjs1_2.13 tests_sjs1_3 tests_2.12 tests_2.13 tests_3 example_2.12 example_2.13 example_3 tests_native0.4_2.12 tests_native0.4_2.13 tests_native0.4_3
+          modules-ignore: skunkjs_2.12 skunkjs_2.13 skunkjs_3 docs_2.12 docs_2.13 docs_3 skunkjvm_2.12 skunkjvm_2.13 skunkjvm_3 skunknative_2.12 skunknative_2.13 skunknative_3 tests_sjs1_2.12 tests_sjs1_2.13 tests_sjs1_3 tests_2.12 tests_2.13 tests_3 example_2.12 example_2.13 example_3 tests_native0.4_2.12 tests_native0.4_2.13 tests_native0.4_3
           configs-ignore: test scala-tool scala-doc-tool test-internal
 
   validate-steward:

--- a/build.sbt
+++ b/build.sbt
@@ -97,7 +97,6 @@ lazy val commonSettings = Seq(
 )
 
 lazy val skunk = tlCrossRootProject
-  .settings(name := "skunk")
   .aggregate(core, tests, circe, refined, postgis, example, unidocs)
   .settings(commonSettings)
 


### PR DESCRIPTION
As we learned in https://github.com/typelevel/cats/pull/4644, if the root module has the `name` SBT setting filled in, it leads to an issue with `modules-ignore` in the `submit-dependencies` CI job. But still, it's a pretty minor issue no one other than me is worried about.