### PR TITLE
Fix missing `sbt-scoverage` plugin for Scala 2.13.15

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
 addSbtPlugin("org.typelevel"             % "sbt-typelevel"      % "0.7.2")
 addSbtPlugin("org.typelevel"             % "sbt-typelevel-site" % "0.7.2")
 addSbtPlugin("com.timushev.sbt"          % "sbt-updates"        % "0.6.4")
-addSbtPlugin("org.scoverage"             % "sbt-scoverage"      % "2.1.0")
+addSbtPlugin("org.scoverage"             % "sbt-scoverage"      % "2.2.1")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
 addSbtPlugin("com.armanbilge" % "sbt-scala-native-config-brew-github-actions" % "0.3.0")


### PR DESCRIPTION
Fixes the `sbt.librarymanagement.ResolveException: Error downloading org.scoverage:scalac-scoverage-plugin_2.13.15:2.1.1`.