### PR TITLE
Bumped all download/upload-artifact actions to be > v3.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}-${{ matrix.project }}
           path: targets.tar
@@ -171,7 +171,7 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Download target directories (2.12.17, rootJS)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.17-rootJS
 
@@ -181,7 +181,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (2.12.17, rootJVM)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.17-rootJVM
 
@@ -191,7 +191,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (2.12.17, rootNative)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.17-rootNative
 
@@ -201,7 +201,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (2.13.10, rootJS)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.10-rootJS
 
@@ -211,7 +211,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (2.13.10, rootJVM)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.10-rootJVM
 
@@ -221,7 +221,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (2.13.10, rootNative)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.10-rootNative
 
@@ -231,7 +231,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (3.2.1, rootJS)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.1-rootJS
 
@@ -241,7 +241,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (3.2.1, rootJVM)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.1-rootJVM
 
@@ -251,7 +251,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (3.2.1, rootNative)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.1-rootNative
 


### PR DESCRIPTION
Why:
Artifact actions v3 will be deprecated by December 5, 2024.

Impact:
There is a small impact see [here](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes). However, the breaking changes do not affect us.