### PR TITLE
Use `TracerProvider` and `MeterProvider` instead of `Tracer` and `Meter`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,10 @@ jobs:
           export SERVER_CERT=$(cat world/server.crt)
           docker compose up -d
 
+      - name: Update brew
+        if: startsWith(matrix.os, 'ubuntu')
+        run: /home/linuxbrew/.linuxbrew/bin/brew update
+
       - name: Install brew formulae (ubuntu)
         if: (matrix.project == 'skunkNative') && startsWith(matrix.os, 'ubuntu')
         run: /home/linuxbrew/.linuxbrew/bin/brew install s2n utf8proc

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,13 @@ ThisBuild / githubWorkflowOSes := Seq("ubuntu-latest")
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))
 ThisBuild / tlJdkRelease := Some(8)
 ThisBuild / resolvers += Resolver.sonatypeCentralSnapshots
-ThisBuild / githubWorkflowBuildPreamble ++= nativeBrewInstallWorkflowSteps.value
+ThisBuild / githubWorkflowBuildPreamble ++= Seq(
+  WorkflowStep.Run(
+    commands = List("/home/linuxbrew/.linuxbrew/bin/brew update"),
+    name = Some("Update brew"),
+    cond = Some("startsWith(matrix.os, 'ubuntu')")
+  )
+) ++ nativeBrewInstallWorkflowSteps.value
 ThisBuild / nativeBrewInstallCond := Some("matrix.project == 'skunkNative'")
 
 lazy val setupCertAndDocker = Seq(
@@ -119,11 +125,14 @@ lazy val skunk = tlCrossRootProject
 lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Full)
   .in(file("modules/core"))
-  .enablePlugins(AutomateHeaderPlugin)
+  .enablePlugins(AutomateHeaderPlugin, BuildInfoPlugin)
   .settings(commonSettings)
   .settings(
     name := "skunk-core",
     description := "Tagless, non-blocking data access library for Postgres.",
+    buildInfoKeys := Seq[BuildInfoKey](version),
+    buildInfoPackage := "skunk",
+    buildInfoOptions += BuildInfoOption.PackagePrivate,
     libraryDependencies ++= Seq(
       "org.typelevel"          %%% "cats-core"               % "2.13.0",
       "org.typelevel"          %%% "cats-effect"             % "3.7.0",

--- a/modules/bench/src/main/scala/skunk/bench/SelectBench.scala
+++ b/modules/bench/src/main/scala/skunk/bench/SelectBench.scala
@@ -11,13 +11,13 @@ import skunk.codec.all._
 
 import java.sql.DriverManager
 import org.openjdk.jmh.annotations._
-import org.typelevel.otel4s.trace.Tracer
-import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.trace.TracerProvider
+import org.typelevel.otel4s.metrics.MeterProvider
 
 @State(Scope.Benchmark)
 object SelectBenchScope {
-  implicit val tracer: Tracer[IO] = Tracer.noop[IO]
-  implicit val meter: Meter[IO] = Meter.noop[IO]
+  implicit val tracerProvider: TracerProvider[IO] = TracerProvider.noop[IO]
+  implicit val meterProvider: MeterProvider[IO] = MeterProvider.noop[IO]
 
   val defaultChunkSize = 512
 

--- a/modules/core/shared/src/main/scala/Session.scala
+++ b/modules/core/shared/src/main/scala/Session.scala
@@ -14,8 +14,10 @@ import fs2.io.net.{ Network, Socket, SocketOption }
 import fs2.Pipe
 import fs2.Stream
 import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.metrics.MeterProvider
 import org.typelevel.otel4s.metrics.Histogram
 import org.typelevel.otel4s.trace.Tracer
+import org.typelevel.otel4s.trace.TracerProvider
 import skunk.codec.all.bool
 import skunk.data._
 import skunk.exception.SkunkException
@@ -478,7 +480,7 @@ object Session {
    * @param queryCacheSize        size of the session-level cache for query checking; defaults to 2048
    * @param parseCacheSize        size of the pool-level cache for parsing statements; defaults to 2048
    */
-  final class Builder[F[_]: Temporal: Meter: Network: Console] private (
+  final class Builder[F[_]: Temporal: TracerProvider: MeterProvider: Network: Console] private (
     val connectionType: ConnectionType,
     val host: Host,
     val port: Port,
@@ -613,13 +615,7 @@ object Session {
      * single-session pool.
      * @see pooled
      */
-    def single(implicit T: Tracer[F]): Resource[F, Session[F]] = pooled(1).flatten
-
-    /**
-     * Like [[single]] but instead of taking `Tracer[F]` implicitly, a function is returned that
-     * accepts an explicit `Tracer[F]`.
-     */
-    def singleExplicitTracer: Tracer[F] => Resource[F, Session[F]] = single(_)
+    def single: Resource[F, Session[F]] = pooled(1).flatten
 
     /**
      * Resource yielding a `SessionPool` managing up to `max` concurrent `Session`s. Typically you
@@ -635,14 +631,14 @@ object Session {
      * reasonable, but it will result in a resource that allocates a new pool for each session, which
      * is probably not what you want.
      */
-    def pooled(max: Int)(implicit T: Tracer[F]): Resource[F, Resource[F, Session[F]]] =
-      pooledExplicitTracer(max).map(_.apply(T))
+    def pooled(max: Int): Resource[F, Resource[F, Session[F]]] =
+      for {
+        tracer <- Resource.eval(TracerProvider[F].tracer("org.typelevel.skunk").withVersion(BuildInfo.version).get)
+        meter  <- Resource.eval(MeterProvider[F].meter("org.typelevel.skunk").withVersion(BuildInfo.version).get)
+        pool   <- pooledWithTracer(max)(meter)
+      } yield pool(tracer)
 
-    /**
-     * Like [[pooled]] but instead of taking `Tracer[F]` implicitly, the inner resource is replaced
-     * by a function which accepts an explicit `Tracer[F]`.
-     */
-    def pooledExplicitTracer(max: Int): Resource[F, Tracer[F] => Resource[F, Session[F]]] = {
+    private def pooledWithTracer(max: Int)(implicit M: Meter[F]): Resource[F, Tracer[F] => Resource[F, Session[F]]] = {
       val logger: String => F[Unit] = s => Console[F].println(s"TLS: $s")
       for {
         dc      <- Resource.eval(Describe.Cache.empty[F](commandCacheSize, queryCacheSize))
@@ -706,7 +702,7 @@ object Session {
    }}}
    */
   object Builder {
-    def apply[F[_]: Temporal: Meter: Network: Console]: Builder[F] =
+    def apply[F[_]: Temporal: TracerProvider: MeterProvider: Network: Console]: Builder[F] =
       new Builder[F](
         connectionType = ConnectionType.TCP,
         host = host"localhost",
@@ -753,7 +749,7 @@ object Session {
    * @group Constructors
    */
   @deprecated("Use Session.Builder[F].pooled instead", "1.0.0-M11")
-  def pooled[F[_]: Temporal: Tracer: Meter: Network: Console](
+  def pooled[F[_]: Temporal: TracerProvider: MeterProvider: Network: Console](
     host:          String,
     port:          Int            = 5432,
     user:          String,
@@ -790,70 +786,13 @@ object Session {
       
 
   /**
-   * Resource yielding a function from Tracer to `SessionPool` managing up to `max` concurrent `Session`s. Typically you
-   * will `use` this resource once on application startup and pass the resulting
-   * `Resource[F, Session[F]]` to the rest of your program.
-   *
-   * The pool maintains a cache of queries and commands that have been checked against the schema,
-   * eliminating the need to check them more than once. If your program is changing the schema on
-   * the fly than you probably don't want this behavior; you can disable it by setting the
-   * `commandCache` and `queryCache` parameters to zero.
-   *
-   * @param host          Postgres server host
-   * @param port          Postgres port, default 5432
-   * @param user          Postgres user
-   * @param database      Postgres database
-   * @param max           Maximum concurrent sessions
-   * @param debug
-   * @param strategy
-   * @param commandCache  Size of the cache for command checking
-   * @param queryCache    Size of the cache for query checking
-   * @group Constructors
-   */
-  @deprecated("Use Session.Builder[F].pooledExplicitTracer instead", "1.0.0-M11")
-  def pooledF[F[_]: Temporal: Meter: Network: Console](
-    host:          String,
-    port:          Int            = 5432,
-    user:          String,
-    database:      String,
-    password:      Option[String] = none,
-    max:           Int,
-    debug:         Boolean        = false,
-    strategy:      TypingStrategy = TypingStrategy.BuiltinsOnly,
-    ssl:           SSL            = SSL.None,
-    parameters:    Map[String, String] = Session.DefaultConnectionParameters,
-    socketOptions: List[SocketOption] = Session.DefaultSocketOptions,
-    commandCache:  Int = 2048,
-    queryCache:    Int = 2048,
-    parseCache:    Int = 2048,
-    readTimeout:   Duration = Duration.Inf,
-    redactionStrategy: RedactionStrategy = RedactionStrategy.OptIn,
-  ): Resource[F, Tracer[F] => Resource[F, Session[F]]] =
-    Builder[F]
-      .withHost(host)
-      .withPort(port)
-      .withCredentials(Credentials(user, password))
-      .withDatabase(database)
-      .withDebug(debug)
-      .withTypingStrategy(strategy)
-      .withRedactionStrategy(redactionStrategy)
-      .withSSL(ssl)
-      .withConnectionParameters(parameters)
-      .withSocketOptions(socketOptions)
-      .withReadTimeout(readTimeout)
-      .withCommandCacheSize(commandCache)
-      .withQueryCacheSize(queryCache)
-      .withParseCacheSize(parseCache)
-      .pooledExplicitTracer(max)
-
-  /**
    * Resource yielding logically unpooled sessions. This can be convenient for demonstrations and
    * programs that only need a single session. In reality each session is managed by its own
    * single-session pool. This method is shorthand for `Session.pooled(..., max = 1, ...).flatten`.
    * @see pooled
    */
   @deprecated("Use Session.Builder[F].single instead", "1.0.0-M11")
-  def single[F[_]: Temporal: Tracer: Meter: Network: Console](
+  def single[F[_]: Temporal: TracerProvider: MeterProvider: Network: Console](
     host:         String,
     port:         Int            = 5432,
     user:         String,
@@ -884,45 +823,6 @@ object Session {
       .withQueryCacheSize(queryCache)
       .withParseCacheSize(parseCache)
       .single
-
-  /**
-   * Resource yielding logically unpooled sessions given a Tracer. This can be convenient for demonstrations and
-   * programs that only need a single session. In reality each session is managed by its own
-   * single-session pool.
-   * @see pooledF
-   */
-  @deprecated("Use Session.Builder[F].singleExplicitTracer instead", "1.0.0-M11")
-  def singleF[F[_]: Temporal: Meter: Network: Console](
-    host:         String,
-    port:         Int            = 5432,
-    user:         String,
-    database:     String,
-    password:     Option[String] = none,
-    debug:        Boolean        = false,
-    strategy:     TypingStrategy = TypingStrategy.BuiltinsOnly,
-    ssl:          SSL            = SSL.None,
-    parameters:   Map[String, String] = Session.DefaultConnectionParameters,
-    commandCache: Int = 2048,
-    queryCache:   Int = 2048,
-    parseCache:   Int = 2048,
-    readTimeout:  Duration = Duration.Inf,
-    redactionStrategy: RedactionStrategy = RedactionStrategy.OptIn,
-  ): Tracer[F] => Resource[F, Session[F]] =
-    Builder[F]
-      .withHost(host)
-      .withPort(port)
-      .withCredentials(Credentials(user, password))
-      .withDatabase(database)
-      .withDebug(debug)
-      .withTypingStrategy(strategy)
-      .withRedactionStrategy(redactionStrategy)
-      .withSSL(ssl)
-      .withConnectionParameters(parameters)
-      .withReadTimeout(readTimeout)
-      .withCommandCacheSize(commandCache)
-      .withQueryCacheSize(queryCache)
-      .withParseCacheSize(parseCache)
-      .singleExplicitTracer
 
   /**
    * Construct a `Session` by wrapping an existing `Protocol`, which we assume has already been

--- a/modules/docs/src/main/laika/reference/Sessions.md
+++ b/modules/docs/src/main/laika/reference/Sessions.md
@@ -1,7 +1,7 @@
 ```scala mdoc:invisible
 import cats.effect._, skunk._
-implicit def dummyTrace: org.typelevel.otel4s.trace.Tracer[IO] = ???
-implicit def dummyMeter: org.typelevel.otel4s.metrics.Meter[IO] = ???
+implicit def dummyTracerProvider: org.typelevel.otel4s.trace.TracerProvider[IO] = ???
+implicit def dummyMeterProvider: org.typelevel.otel4s.metrics.MeterProvider[IO] = ???
 ```
 
 # Sessions
@@ -82,4 +82,3 @@ A `Session` is ultimately a TCP Socket, and as such a number of error conditions
 | Disconnection | `EofException` | The underlying socket has been closed. |
 
 Note that if you wish to **limit statement execution time**, it's best to use the `statement_timeout` session parameter (settable via SQL or via `parameters` above), which will raise a server-side exception on expiration and will _not_ invalidate the session.
-

--- a/modules/docs/src/main/laika/tutorial/Command.md
+++ b/modules/docs/src/main/laika/tutorial/Command.md
@@ -4,12 +4,12 @@ import cats.implicits._
 import skunk._
 import skunk.implicits._
 import skunk.codec.all._
-import org.typelevel.otel4s.trace.Tracer
-import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.trace.TracerProvider
+import org.typelevel.otel4s.metrics.MeterProvider
 import fs2.Stream
 val s: Session[IO] = null
-implicit val tracer: Tracer[IO] = Tracer.noop
-implicit val meter: Meter[IO] = Meter.noop
+implicit val tracerProvider: TracerProvider[IO] = TracerProvider.noop
+implicit val meterProvider: MeterProvider[IO] = MeterProvider.noop
 ```
 
 # Commands
@@ -199,8 +199,8 @@ Here is a complete program listing that demonstrates our knowledge thus far, usi
 import cats.Monad
 import cats.effect._
 import cats.syntax.all._
-import org.typelevel.otel4s.trace.Tracer
-import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.trace.TracerProvider
+import org.typelevel.otel4s.metrics.MeterProvider
 import skunk._
 import skunk.codec.all._
 import skunk.implicits._
@@ -248,8 +248,8 @@ object PetService {
 
 object CommandExample extends IOApp {
 
-  implicit val tracer: Tracer[IO] = Tracer.noop
-  implicit val meter: Meter[IO] = Meter.noop
+  implicit val tracerProvider: TracerProvider[IO] = TracerProvider.noop
+  implicit val meterProvider: MeterProvider[IO] = MeterProvider.noop
 
   // a source of sessions
   val session: Resource[IO, Session[IO]] =

--- a/modules/docs/src/main/laika/tutorial/Query.md
+++ b/modules/docs/src/main/laika/tutorial/Query.md
@@ -252,8 +252,8 @@ import skunk._
 import skunk.implicits._
 import skunk.codec.all._
 import java.time.OffsetDateTime
-implicit def dummyTrace: org.typelevel.otel4s.trace.Tracer[IO] = org.typelevel.otel4s.trace.Tracer.noop
-implicit def dummyMeter: org.typelevel.otel4s.metrics.Meter[IO] = org.typelevel.otel4s.metrics.Meter.noop
+implicit def dummyTracerProvider: org.typelevel.otel4s.trace.TracerProvider[IO] = org.typelevel.otel4s.trace.TracerProvider.noop
+implicit def dummyMeterProvider: org.typelevel.otel4s.metrics.MeterProvider[IO] = org.typelevel.otel4s.metrics.MeterProvider.noop
 
 object QueryExample extends IOApp {
 
@@ -328,8 +328,8 @@ import skunk._
 import skunk.implicits._
 import skunk.codec.all._
 import java.time.OffsetDateTime
-import org.typelevel.otel4s.trace.Tracer
-import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.trace.TracerProvider
+import org.typelevel.otel4s.metrics.MeterProvider
 import fs2.Stream
 import cats.Applicative
 
@@ -372,8 +372,8 @@ object Service {
 
 object QueryExample2 extends IOApp {
 
-  implicit val tracer: Tracer[IO] = Tracer.noop
-  implicit val meter: Meter[IO] = Meter.noop
+  implicit val tracerProvider: TracerProvider[IO] = TracerProvider.noop
+  implicit val meterProvider: MeterProvider[IO] = MeterProvider.noop
 
   // a source of sessions
   val session: Resource[IO, Session[IO]] =
@@ -442,4 +442,3 @@ For reference, the `country` table looks like this.
 | headofstate    | character varying |           |
 | capital        | integer           |           |
 | code2          | character(2)      | not null  |
-

--- a/modules/docs/src/main/laika/tutorial/Setup.md
+++ b/modules/docs/src/main/laika/tutorial/Setup.md
@@ -35,13 +35,13 @@ import cats.effect._
 import skunk._
 import skunk.implicits._
 import skunk.codec.all._
-import org.typelevel.otel4s.trace.Tracer
-import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.trace.TracerProvider
+import org.typelevel.otel4s.metrics.MeterProvider
 
 object Hello extends IOApp {
 
-  implicit val tracer: Tracer[IO] = Tracer.noop              // (1)
-  implicit val meter: Meter[IO] = Meter.noop
+  implicit val tracerProvider: TracerProvider[IO] = TracerProvider.noop // (1)
+  implicit val meterProvider: MeterProvider[IO] = MeterProvider.noop
 
   val session: Resource[IO, Session[IO]] =
     Session.Builder[IO]                                      // (2)
@@ -64,7 +64,7 @@ object Hello extends IOApp {
 
 Let's examine the code above.
 
-- At ① we define the no-op `Tracer` and `Meter`, which allows us to run Skunk programs with execution tracing and metrics disabled. We will revisit [Telemetry](Telemetry.md) in a later section.
+- At ① we define the no-op `TracerProvider` and `MeterProvider`, which allows us to run Skunk programs with execution tracing and metrics disabled. We will revisit [Telemetry](Telemetry.md) in a later section.
 - At ② we define a [Resource](https://typelevel.org/cats-effect/datatypes/resource.html) that yields un-pooled [Session](../reference/Sessions.md) values and ensures that they are closed after use. We specify the host, port, user, database, and password (note: we didn't actually need to specify the host and port as the default host is localhost and the default port is 5432 -- see [Session](../reference/Sessions.md) for information on ther connection options).
 - At ③ we `use` the resource, specifying a block to execute during the `Session`'s lifetime. No matter how the block terminates (success, failure, cancellation) the `Session` will be closed properly.
 - At ④ we use the [sql interpolator](../reference/Fragments.md) to construct a `Query` that selects a single column of schema type `date` (yielding `d`, a value of type `java.time.LocalDate`), then we ask the session to execute it, expecting a *unique* value back; i.e., exactly one row.
@@ -87,4 +87,3 @@ Here are some modifications that will cause runtime failures. Give them a try an
 - Change the decoder from `date` to another type like `timestamp`.
 
 We will see more examples later in the tutorial.
-

--- a/modules/docs/src/main/laika/tutorial/Telemetry.md
+++ b/modules/docs/src/main/laika/tutorial/Telemetry.md
@@ -1,6 +1,6 @@
 # Telemetry
 
-Skunk uses [OpenTelemtry](https://opentelemetry.io/), using the [otel4s](https://github.com/typelevel/otel4s) implementation.
+Skunk uses [OpenTelemetry](https://opentelemetry.io/), using the [otel4s](https://github.com/typelevel/otel4s). Session construction requires a `TracerProvider` and a `MeterProvider`; Skunk uses them to acquire its own versioned tracer and meter.
 
 ## Metrics
 
@@ -8,7 +8,7 @@ Skunk provides the [`db.client.operation.duration`](https://opentelemetry.io/doc
 
 ### I Don't Care
 
-If you don't care about metrics you can use the **no-op meter** to disable metrics entirely (`org.typelevel.otel4s.metrics.Meter`).
+If you don't care about metrics you can use the **no-op meter** to disable metrics entirely (`org.typelevel.otel4s.metrics.MeterProvider.noop`).
 
 ## Tracing
 
@@ -16,7 +16,7 @@ If you don't care about metrics you can use the **no-op meter** to disable metri
 
 If you don't care about tracing you have two choices:
 
-- Use the **no-op tracer** to disable tracing entirely (`org.typelevel.otel4s.Tracer.noop`).
+- Use the **no-op tracer** to disable tracing entirely (`org.typelevel.otel4s.TracerProvider.noop`).
 - Use the **log tracer** to log completed traces to a [log4cats](https://typelevel.org/log4cats/) logger.
 
 ### Tracing with Jaeger

--- a/modules/docs/src/main/laika/tutorial/Transactions.md
+++ b/modules/docs/src/main/laika/tutorial/Transactions.md
@@ -95,8 +95,8 @@ Here is a complete program listing that demonstrates our knowledge thus far.
 
 import cats.effect._
 import cats.implicits._
-import org.typelevel.otel4s.trace.Tracer
-import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.trace.TracerProvider
+import org.typelevel.otel4s.metrics.MeterProvider
 import skunk._
 import skunk.codec.all._
 import skunk.implicits._
@@ -156,8 +156,8 @@ object PetService {
 
 object TransactionExample extends IOApp {
 
-  implicit val tracer: Tracer[IO] = Tracer.noop
-  implicit val meter: Meter[IO] = Meter.noop
+  implicit val tracerProvider: TracerProvider[IO] = TracerProvider.noop
+  implicit val meterProvider: MeterProvider[IO] = MeterProvider.noop
 
   // a source of sessions
   val session: Resource[IO, Session[IO]] =

--- a/modules/example/src/main/scala/AppliedFragments.scala
+++ b/modules/example/src/main/scala/AppliedFragments.scala
@@ -6,16 +6,16 @@ package example
 
 import cats.effect._
 import cats.implicits._
-import org.typelevel.otel4s.trace.Tracer
-import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.trace.TracerProvider
+import org.typelevel.otel4s.metrics.MeterProvider
 import skunk._
 import skunk.implicits._
 import skunk.codec.all._
 
 object AppliedFragments extends IOApp {
 
-  implicit val tracer: Tracer[IO] = Tracer.noop
-  implicit val meter: Meter[IO] = Meter.noop
+  implicit val tracerProvider: TracerProvider[IO] = TracerProvider.noop
+  implicit val meterProvider: MeterProvider[IO] = MeterProvider.noop
 
   val session: Resource[IO, Session[IO]] =
     Session.Builder[IO]

--- a/modules/example/src/main/scala/Channel.scala
+++ b/modules/example/src/main/scala/Channel.scala
@@ -7,13 +7,13 @@ package example
 import cats.effect._
 import skunk._
 import skunk.implicits._
-import org.typelevel.otel4s.trace.Tracer
-import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.trace.TracerProvider
+import org.typelevel.otel4s.metrics.MeterProvider
 
 object Channel extends IOApp {
 
-  implicit val tracer: Tracer[IO] = Tracer.noop
-  implicit val meter: Meter[IO] = Meter.noop
+  implicit val tracerProvider: TracerProvider[IO] = TracerProvider.noop
+  implicit val meterProvider: MeterProvider[IO] = MeterProvider.noop
 
   val session: Resource[IO, Session[IO]] =
     Session.Builder[IO]

--- a/modules/example/src/main/scala/Error.scala
+++ b/modules/example/src/main/scala/Error.scala
@@ -9,13 +9,13 @@ import cats.syntax.all._
 import skunk._
 import skunk.implicits._
 import skunk.codec.all._
-import org.typelevel.otel4s.trace.Tracer
-import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.trace.TracerProvider
+import org.typelevel.otel4s.metrics.MeterProvider
 
 object Error extends IOApp {
 
-  implicit val trace: Tracer[IO] = Tracer.noop
-  implicit val meter: Meter[IO] = Meter.noop
+  implicit val tracerProvider: TracerProvider[IO] = TracerProvider.noop
+  implicit val meterProvider: MeterProvider[IO] = MeterProvider.noop
 
   val session: Resource[IO, Session[IO]] =
     Session.Builder[IO]

--- a/modules/example/src/main/scala/Join.scala
+++ b/modules/example/src/main/scala/Join.scala
@@ -10,13 +10,13 @@ import fs2._
 import skunk._
 import skunk.implicits._
 import skunk.codec.all._
-import org.typelevel.otel4s.trace.Tracer
-import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.trace.TracerProvider
+import org.typelevel.otel4s.metrics.MeterProvider
 
 object Join extends IOApp with StreamOps {
 
-  implicit val tracer: Tracer[IO] = Tracer.noop
-  implicit val meter: Meter[IO] = Meter.noop
+  implicit val tracerProvider: TracerProvider[IO] = TracerProvider.noop
+  implicit val meterProvider: MeterProvider[IO] = MeterProvider.noop
 
   val session: Resource[IO, Session[IO]] =
     Session.Builder[IO]

--- a/modules/example/src/main/scala/Main.scala
+++ b/modules/example/src/main/scala/Main.scala
@@ -10,15 +10,15 @@ import skunk.implicits._
 import cats.effect._
 import cats.syntax.all._
 import fs2._
-import org.typelevel.otel4s.trace.Tracer
-import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.trace.TracerProvider
+import org.typelevel.otel4s.metrics.MeterProvider
 
 // This does a lot of stuff and is mostly just to test features as they're being added. This class
 // will probably go away.
 object Main extends IOApp {
 
-  implicit val trace: Tracer[IO] = Tracer.noop
-  implicit val meter: Meter[IO] = Meter.noop
+  implicit val tracerProvider: TracerProvider[IO] = TracerProvider.noop
+  implicit val meterProvider: MeterProvider[IO] = MeterProvider.noop
 
   case class Country(name: String, code: String, indepyear: Option[Short], population: Int)
 
@@ -99,4 +99,3 @@ object Main extends IOApp {
     }
 
 }
-

--- a/modules/example/src/main/scala/Math1.scala
+++ b/modules/example/src/main/scala/Math1.scala
@@ -9,13 +9,13 @@ import cats.syntax.all._
 import skunk._
 import skunk.implicits._
 import skunk.codec.numeric.{ int4, float8 }
-import org.typelevel.otel4s.trace.Tracer
-import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.trace.TracerProvider
+import org.typelevel.otel4s.metrics.MeterProvider
 
 object Math1 extends IOApp {
 
-  implicit val tracer: Tracer[IO] = Tracer.noop
-  implicit val meter: Meter[IO] = Meter.noop
+  implicit val tracerProvider: TracerProvider[IO] = TracerProvider.noop
+  implicit val meterProvider: MeterProvider[IO] = MeterProvider.noop
 
   val session: Resource[IO, Session[IO]] =
     Session.Builder[IO]

--- a/modules/example/src/main/scala/Math2.scala
+++ b/modules/example/src/main/scala/Math2.scala
@@ -10,13 +10,13 @@ import cats.syntax.all._
 import skunk._
 import skunk.implicits._
 import skunk.codec.numeric.{ int4, float8 }
-import org.typelevel.otel4s.trace.Tracer
-import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.trace.TracerProvider
+import org.typelevel.otel4s.metrics.MeterProvider
 
 object Math2 extends IOApp {
 
-  implicit val tracer: Tracer[IO] = Tracer.noop
-  implicit val meter: Meter[IO] = Meter.noop
+  implicit val tracerProvider: TracerProvider[IO] = TracerProvider.noop
+  implicit val meterProvider: MeterProvider[IO] = MeterProvider.noop
 
   val session: Resource[IO, Session[IO]] =
     Session.Builder[IO]

--- a/modules/example/src/main/scala/Minimal1.scala
+++ b/modules/example/src/main/scala/Minimal1.scala
@@ -8,13 +8,13 @@ import cats.effect._
 import skunk._
 import skunk.implicits._
 import skunk.codec.all._
-import org.typelevel.otel4s.trace.Tracer
-import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.trace.TracerProvider
+import org.typelevel.otel4s.metrics.MeterProvider
 
 object Minimal1 extends IOApp {
 
-  implicit val tracer: Tracer[IO] = Tracer.noop[IO]
-  implicit val mterj: Meter[IO] = Meter.noop[IO]
+  implicit val tracerProvider: TracerProvider[IO] = TracerProvider.noop[IO]
+  implicit val meterProvider: MeterProvider[IO] = MeterProvider.noop[IO]
 
   val session: Resource[IO, Session[IO]] =
     Session.Builder[IO]

--- a/modules/example/src/main/scala/Minimal2.scala
+++ b/modules/example/src/main/scala/Minimal2.scala
@@ -12,15 +12,16 @@ import skunk.implicits._
 import skunk.codec.all._
 import org.typelevel.otel4s.Attribute
 import org.typelevel.otel4s.oteljava.OtelJava
-import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.metrics.MeterProvider
 import org.typelevel.otel4s.trace.Tracer
+import org.typelevel.otel4s.trace.TracerProvider
 import fs2.io.net.Network
 import cats.effect.std.Console
 
 object Minimal2 extends IOApp {
 
 
-  def session[F[_]: Temporal: Tracer: Meter: Console: Network]: Resource[F, Session[F]] =
+  def session[F[_]: Temporal: TracerProvider: MeterProvider: Console: Network]: Resource[F, Session[F]] =
     Session.Builder[F]
       .withUserAndPassword("jimmy", "banana")
       .withDatabase("world")
@@ -47,21 +48,25 @@ object Minimal2 extends IOApp {
       }
     }
 
-  def runF[F[_]: Temporal: Tracer: Meter: Console: Network]: F[ExitCode] =
+  def runF[F[_]: Temporal: TracerProvider: Tracer: MeterProvider: Console: Network]: F[ExitCode] =
     session.use { s =>
       List("A%", "B%").parTraverse(p => lookup(p, s))
     } as ExitCode.Success
 
-  def getTelemetry[F[_]: Async: LiftIO]: Resource[F, (Tracer[F], Meter[F])] =
+  def getTelemetry[F[_]: Async: LiftIO]: Resource[F, (TracerProvider[F], Tracer[F], MeterProvider[F])] =
     OtelJava.autoConfigured[F]()
       .evalMap{ otel =>
-        (otel.tracerProvider.tracer("skunk-http4s-example").get, otel.meterProvider.meter("skunk-http4s-example").get).tupled
+        otel.tracerProvider
+          .tracer("skunk-http4s-example")
+          .get
+          .map(tracer => (otel.tracerProvider, tracer, otel.meterProvider))
       }
 
   def run(args: List[String]): IO[ExitCode] =
-    getTelemetry[IO].use { case (tracer, meter) =>
-      implicit val M = meter
+    getTelemetry[IO].use { case (tracerProvider, tracer, meterProvider) =>
       implicit val T = tracer
+      implicit val TP = tracerProvider
+      implicit val MP = meterProvider
       T.span("root").surround {
         runF[IO] *> runF[IO]
       }

--- a/modules/example/src/main/scala/Minimal3.scala
+++ b/modules/example/src/main/scala/Minimal3.scala
@@ -10,13 +10,13 @@ import fs2.Stream.resource
 import skunk._
 import skunk.implicits._
 import skunk.codec.all._
-import org.typelevel.otel4s.trace.Tracer
-import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.trace.TracerProvider
+import org.typelevel.otel4s.metrics.MeterProvider
 
 object Minimal3 extends IOApp {
 
-  implicit val trace: Tracer[IO] = Tracer.noop
-  implicit val meter: Meter[IO] = Meter.noop
+  implicit val tracerProvider: TracerProvider[IO] = TracerProvider.noop
+  implicit val meterProvider: MeterProvider[IO] = MeterProvider.noop
 
   val session: Resource[IO, Session[IO]] =
     Session.Builder[IO]

--- a/modules/example/src/main/scala/Transaction.scala
+++ b/modules/example/src/main/scala/Transaction.scala
@@ -7,15 +7,15 @@ package example
 import cats.effect._
 import cats.syntax.all._
 import skunk._, skunk.implicits._, skunk.codec.all.int4
-import org.typelevel.otel4s.trace.Tracer
+import org.typelevel.otel4s.trace.TracerProvider
 import cats.effect.std.Console
 import fs2.io.net.Network
-import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.metrics.MeterProvider
 
 object Transaction extends IOApp {
 
-  implicit def tracer[F[_]: MonadCancelThrow]: Tracer[F] = Tracer.noop
-  implicit def meter[F[_]: MonadCancelThrow]: Meter[F] = Meter.noop
+  implicit def tracerProvider[F[_]: MonadCancelThrow]: TracerProvider[F] = TracerProvider.noop
+  implicit def meterProvider[F[_]: MonadCancelThrow]: MeterProvider[F] = MeterProvider.noop
 
   def session[F[_]: Temporal: Console: Network]: Resource[F, Session[F]] =
     Session.Builder[F]

--- a/modules/example/src/main/scala/Values.scala
+++ b/modules/example/src/main/scala/Values.scala
@@ -6,17 +6,17 @@ package example
 
 import cats.effect._
 import cats.syntax.all._
-import org.typelevel.otel4s.trace.Tracer
+import org.typelevel.otel4s.trace.TracerProvider
 import skunk._
 import skunk.implicits._
 import skunk.codec.all._
-import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.metrics.MeterProvider
 
 /** Round-trip a list of values. You can use this pattern to do bulk-inserts. */
 object Values extends IOApp {
 
-  implicit val tracer: Tracer[IO] = Tracer.noop
-  implicit val mter: Meter[IO] = Meter.noop
+  implicit val tracerProvider: TracerProvider[IO] = TracerProvider.noop
+  implicit val meterProvider: MeterProvider[IO] = MeterProvider.noop
 
   val session: Resource[IO, Session[IO]] =
     Session.Builder[IO]

--- a/modules/tests/shared/src/main/scala/ffstest/FFramework.scala
+++ b/modules/tests/shared/src/main/scala/ffstest/FFramework.scala
@@ -14,26 +14,37 @@ import skunk.exception._
 import org.typelevel.twiddles._
 import org.typelevel.otel4s.sdk.trace.SdkTraces
 import org.typelevel.otel4s.trace.Tracer
-import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.trace.TracerProvider
+import org.typelevel.otel4s.metrics.MeterProvider
 
 trait FTest extends CatsEffectSuite with FTestPlatform {
 
-  implicit val meter: Meter[IO] = Meter.noop
+  implicit val meterProvider: MeterProvider[IO] = MeterProvider.noop
 
-  private def withinSpan[A](name: String)(body: Tracer[IO] => IO[A]): IO[A] =
+  private def withinSpan[A](name: String)(body: (TracerProvider[IO], Tracer[IO]) => IO[A]): IO[A] =
     SdkTraces
       .autoConfigured[IO](_.addExporterConfigurer(OtlpSpanExporterAutoConfigure[IO]))
-      .evalMap(_.tracerProvider.get(getClass.getName()))
-      .use(tracer => tracer.span(spanNameForTest(name)).surround(body(tracer)))
+      .use { traces =>
+        val tracerProvider = traces.tracerProvider
+        tracerProvider
+          .get(getClass.getName())
+          .flatMap(tracer => tracer.span(spanNameForTest(name)).surround(body(tracerProvider, tracer)))
+      }
 
   private def spanNameForTest(name: String): String =
     s"${getClass.getSimpleName} - $name"
 
-  def tracedTest[A](name: String)(body: Tracer[IO] => IO[A])(implicit loc: Location): Unit =
-    test(name)(withinSpan(name)(body))
+  def tracedTest[A](name: String)(body: TracerProvider[IO] => IO[A])(implicit loc: Location): Unit =
+    test(name)(withinSpan(name)((provider, _) => body(provider)))
 
-  def tracedTest[A](options: TestOptions)(body: Tracer[IO] => IO[A])(implicit loc: Location): Unit =
-    test(options)(withinSpan(options.name)(body))
+  def tracedTest[A](options: TestOptions)(body: TracerProvider[IO] => IO[A])(implicit loc: Location): Unit =
+    test(options)(withinSpan(options.name)((provider, _) => body(provider)))
+
+  def tracedTestWithTracer[A](name: String)(body: Tracer[IO] => IO[A])(implicit loc: Location): Unit =
+    test(name)(withinSpan(name)((_, tracer) => body(tracer)))
+
+  def tracedTestWithTracer[A](options: TestOptions)(body: Tracer[IO] => IO[A])(implicit loc: Location): Unit =
+    test(options)(withinSpan(options.name)((_, tracer) => body(tracer)))
 
   def pureTest(name: String)(f: => Boolean): Unit = test(name)(assert(name, f))
   def fail[A](msg: String): IO[A] = IO.raiseError(new AssertionError(msg))

--- a/modules/tests/shared/src/test/scala/DescribeCacheTest.scala
+++ b/modules/tests/shared/src/test/scala/DescribeCacheTest.scala
@@ -8,7 +8,7 @@ import skunk.implicits._
 import skunk.codec.numeric.int4
 import cats.syntax.all._
 import cats.effect.IO
-import org.typelevel.otel4s.trace.Tracer
+import org.typelevel.otel4s.trace.TracerProvider
 import skunk.exception.PostgresErrorException
 
 class DescribeCacheTest extends SkunkTest {
@@ -26,7 +26,7 @@ class DescribeCacheTest extends SkunkTest {
     }
   }
 
-  tracedTest("describe cache should be not shared across sessions from different pools") { implicit tracer: Tracer[IO] =>
+  tracedTest("describe cache should be not shared across sessions from different pools") { implicit tracerProvider: TracerProvider[IO] =>
     (pooled(), pooled()).tupled.use { case (p1, p2) =>
       p1.use { s1 =>
         p2.use { s2 =>

--- a/modules/tests/shared/src/test/scala/PoolTest.scala
+++ b/modules/tests/shared/src/test/scala/PoolTest.scala
@@ -45,13 +45,13 @@ class PoolTest extends FTest {
     yielding(fas: _*).map(Resource.make(_)(_ => IO.unit))
 
   // This test leaks
-  tracedTest("error in alloc is rethrown to caller (immediate)") { implicit tracer: Tracer[IO] =>
+  tracedTestWithTracer("error in alloc is rethrown to caller (immediate)") { implicit tracer: Tracer[IO] =>
     val rsrc = Resource.make(IO.raiseError[String](AllocFailure()))(_ => IO.unit)
     val pool = Pool.ofF({(_: Tracer[IO]) => rsrc}, 42)(Recycler.success)
     pool.use(_(Tracer[IO]).use(_ => IO.unit)).assertFailsWith[AllocFailure]
   }
 
-  tracedTest("error in alloc is rethrown to caller (deferral completion following errored cleanup)") { implicit tracer: Tracer[IO] =>
+  tracedTestWithTracer("error in alloc is rethrown to caller (deferral completion following errored cleanup)") { implicit tracer: Tracer[IO] =>
     resourceYielding(IO(1), IO.raiseError(AllocFailure())).flatMap { r =>
       val p = Pool.ofF({(_: Tracer[IO]) => r}, 1)(Recycler[IO, Int](_ => IO.raiseError(ResetFailure())))
       p.use { r =>
@@ -67,7 +67,7 @@ class PoolTest extends FTest {
     }
   }
 
-  tracedTest("error in alloc is rethrown to caller (deferral completion following failed cleanup)") { implicit tracer: Tracer[IO] =>
+  tracedTestWithTracer("error in alloc is rethrown to caller (deferral completion following failed cleanup)") { implicit tracer: Tracer[IO] =>
     resourceYielding(IO(1), IO.raiseError(AllocFailure())).flatMap { r =>
       val p = Pool.ofF({(_: Tracer[IO]) => r}, 1)(Recycler.failure)
       p.use { r =>
@@ -83,7 +83,7 @@ class PoolTest extends FTest {
     }
   }
 
-  tracedTest("error in finalizer does not prevent cleanup of deferreds") { implicit tracer: Tracer[IO] =>
+  tracedTestWithTracer("error in finalizer does not prevent cleanup of deferreds") { implicit tracer: Tracer[IO] =>
     val r = Resource.make(IO(1))(_ => IO.raiseError(ResetFailure()))
     val p = Pool.ofF({(_: Tracer[IO]) => r}, 1)(Recycler.failure)
     p.use { r =>
@@ -92,7 +92,7 @@ class PoolTest extends FTest {
     }.assertFailsWith[ResetFailure]
   }
 
-  tracedTest("provoke dangling deferral cancellation") { implicit tracer: Tracer[IO] =>
+  tracedTestWithTracer("provoke dangling deferral cancellation") { implicit tracer: Tracer[IO] =>
     ints.flatMap { r =>
       val p = Pool.ofF({(_: Tracer[IO]) => r}, 1)(Recycler.failure)
       Deferred[IO, Either[Throwable, Int]].flatMap { d1 =>
@@ -111,19 +111,19 @@ class PoolTest extends FTest {
     }
   }}
 
-  tracedTest("error in free is rethrown to caller") { implicit tracer: Tracer[IO] =>
+  tracedTestWithTracer("error in free is rethrown to caller") { implicit tracer: Tracer[IO] =>
     val rsrc = Resource.make("foo".pure[IO])(_ => IO.raiseError(FreeFailure()))
     val pool = Pool.ofF({(_: Tracer[IO]) => rsrc}, 42)(Recycler.success)
     pool.use(_(tracer).use(_ => IO.unit)).assertFailsWith[FreeFailure]
   }
 
-  tracedTest("error in reset is rethrown to caller") { implicit tracer: Tracer[IO] =>
+  tracedTestWithTracer("error in reset is rethrown to caller") { implicit tracer: Tracer[IO] =>
     val rsrc = Resource.make("foo".pure[IO])(_ => IO.unit)
     val pool = Pool.ofF({(_: Tracer[IO]) => rsrc}, 42)(Recycler[IO, String](_ => IO.raiseError(ResetFailure())))
     pool.use(_(tracer).use(_ => IO.unit)).assertFailsWith[ResetFailure]
   }
 
-  tracedTest("reuse on serial access") { implicit tracer: Tracer[IO] =>
+  tracedTestWithTracer("reuse on serial access") { implicit tracer: Tracer[IO] =>
     ints.map(a => Pool.ofF({(_: Tracer[IO]) => a}, 3)(Recycler.success)).flatMap { factory =>
       factory.use { pool =>
         pool(tracer).use { n =>
@@ -136,7 +136,7 @@ class PoolTest extends FTest {
     }
   }
 
-  tracedTest("allocation on nested access") { implicit tracer: Tracer[IO] =>
+  tracedTestWithTracer("allocation on nested access") { implicit tracer: Tracer[IO] =>
     ints.map(a => Pool.ofF({(_: Tracer[IO]) => a}, 3)(Recycler.success)).flatMap { factory =>
       factory.use { pool =>
         pool(tracer).use { n =>
@@ -152,7 +152,7 @@ class PoolTest extends FTest {
     }
   }
 
-  tracedTest("allocated resource can cause a leak, which will be detected on finalization") { implicit tracer: Tracer[IO] =>
+  tracedTestWithTracer("allocated resource can cause a leak, which will be detected on finalization") { implicit tracer: Tracer[IO] =>
     ints.map(a => Pool.ofF({(_: Tracer[IO]) => a}, 3)(Recycler.success)).flatMap { factory =>
       factory.use { pool =>
         pool(tracer).allocated
@@ -163,7 +163,7 @@ class PoolTest extends FTest {
     }
   }
 
-  tracedTest("unmoored fiber can cause a leak, which will be detected on finalization") { implicit tracer: Tracer[IO] =>
+  tracedTestWithTracer("unmoored fiber can cause a leak, which will be detected on finalization") { implicit tracer: Tracer[IO] =>
     ints.map(a => Pool.ofF({(_: Tracer[IO]) => a}, 3)(Recycler.success)).flatMap { factory =>
       factory.use { pool =>
         pool(tracer).use(_ => IO.never).start *>
@@ -182,7 +182,7 @@ class PoolTest extends FTest {
 
   val shortRandomDelay = IO((Random.nextInt() % 100).abs.milliseconds)
 
-  tracedTest("progress and safety with many fibers") { implicit tracer: Tracer[IO] =>
+  tracedTestWithTracer("progress and safety with many fibers") { implicit tracer: Tracer[IO] =>
     ints.map(a => Pool.ofF({(_: Tracer[IO]) => a}, PoolSize)(Recycler.success)).flatMap { factory =>
       (1 to ConcurrentTasks).toList.parTraverse_{ _ =>
         factory.use { p =>
@@ -197,7 +197,7 @@ class PoolTest extends FTest {
     }
   }
 
-  tracedTest("progress and safety with many fibers and cancellation") { implicit tracer: Tracer[IO] =>
+  tracedTestWithTracer("progress and safety with many fibers and cancellation") { implicit tracer: Tracer[IO] =>
     ints.map(a => Pool.ofF({(_: Tracer[IO]) => a}, PoolSize)(Recycler.success)).flatMap { factory =>
       factory.use { pool =>
         (1 to ConcurrentTasks).toList.parTraverse_{_ =>
@@ -211,7 +211,7 @@ class PoolTest extends FTest {
     }
   }
 
-  tracedTest("progress and safety with many fibers and user failures") { implicit tracer: Tracer[IO] =>
+  tracedTestWithTracer("progress and safety with many fibers and user failures") { implicit tracer: Tracer[IO] =>
     ints.map(a => Pool.ofF({(_: Tracer[IO]) => a}, PoolSize)(Recycler.success)).flatMap { factory =>
       factory.use { pool =>
         (1 to ConcurrentTasks).toList.parTraverse_{ _ =>
@@ -227,7 +227,7 @@ class PoolTest extends FTest {
     }
   }
 
-  tracedTest("progress and safety with many fibers and allocation failures") { implicit tracer: Tracer[IO] =>
+  tracedTestWithTracer("progress and safety with many fibers and allocation failures") { implicit tracer: Tracer[IO] =>
     val alloc = IO(Random.nextBoolean()).flatMap {
       case true  => IO.unit
       case false => IO.raiseError(AllocFailure())
@@ -242,7 +242,7 @@ class PoolTest extends FTest {
     }
   }
 
-  tracedTest("progress and safety with many fibers and freeing failures") { implicit tracer: Tracer[IO] =>
+  tracedTestWithTracer("progress and safety with many fibers and freeing failures") { implicit tracer: Tracer[IO] =>
     val free = IO(Random.nextBoolean()).flatMap {
       case true  => IO.unit
       case false => IO.raiseError(FreeFailure())
@@ -261,7 +261,7 @@ class PoolTest extends FTest {
     }
   }
 
-  tracedTest("progress and safety with many fibers and reset failures") { implicit tracer: Tracer[IO] =>
+  tracedTestWithTracer("progress and safety with many fibers and reset failures") { implicit tracer: Tracer[IO] =>
     val recycle = IO(Random.nextInt(3)).flatMap {
       case 0 => true.pure[IO]
       case 1 => false.pure[IO]

--- a/modules/tests/shared/src/test/scala/RedshiftTest.scala
+++ b/modules/tests/shared/src/test/scala/RedshiftTest.scala
@@ -5,7 +5,7 @@
 package tests
 
 import cats.effect._
-import org.typelevel.otel4s.trace.Tracer
+import org.typelevel.otel4s.trace.TracerProvider
 import skunk._
 import skunk.exception.StartupException
 
@@ -13,7 +13,7 @@ class RedshiftTest extends ffstest.FTest {
 
   object X86ArchOnly extends munit.Tag("X86ArchOnly")
 
-  tracedTest("redshift - successfully connect".tag(X86ArchOnly)) { implicit tracer: Tracer[IO] =>
+  tracedTest("redshift - successfully connect".tag(X86ArchOnly)) { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(5439) // redshift port
       .withConnectionParameters(Session.DefaultConnectionParameters - "IntervalStyle")
@@ -21,7 +21,7 @@ class RedshiftTest extends ffstest.FTest {
       .use(_ => IO.unit)
   }
 
-  tracedTest("redshift - cannot connect with default params".tag(X86ArchOnly)) { implicit tracer: Tracer[IO] =>
+  tracedTest("redshift - cannot connect with default params".tag(X86ArchOnly)) { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(5439) // redshift port
       .single

--- a/modules/tests/shared/src/test/scala/SessionTest.scala
+++ b/modules/tests/shared/src/test/scala/SessionTest.scala
@@ -5,11 +5,13 @@
 package tests
 
 import cats.effect._
-import org.typelevel.otel4s.trace.Tracer.Implicits.noop
+import org.typelevel.otel4s.trace.TracerProvider
 import skunk.Session
 import skunk.exception.SkunkException
 
 class SessionTest extends ffstest.FTest {
+
+  implicit val tracerProvider: TracerProvider[IO] = TracerProvider.noop
 
   test("Invalid host") {
     val e = intercept[SkunkException] {

--- a/modules/tests/shared/src/test/scala/SkunkTest.scala
+++ b/modules/tests/shared/src/test/scala/SkunkTest.scala
@@ -11,14 +11,14 @@ import skunk.data.*
 import skunk.codec.all.*
 import skunk.implicits.*
 import munit.Location
-import org.typelevel.otel4s.trace.Tracer
+import org.typelevel.otel4s.trace.TracerProvider
 import scala.concurrent.duration.Duration
 
 abstract class SkunkTest(debug: Boolean = false, typingStrategy: TypingStrategy = TypingStrategy.BuiltinsOnly) extends ffstest.FTest {
 
-  def session(implicit tracer: Tracer[IO]): Resource[IO, Session[IO]] = session(Duration.Inf)
+  def session(implicit tracerProvider: TracerProvider[IO]): Resource[IO, Session[IO]] = session(Duration.Inf)
 
-  def session(readTimeout: Duration)(implicit tracer: Tracer[IO]): Resource[IO, Session[IO]] =
+  def session(readTimeout: Duration)(implicit tracerProvider: TracerProvider[IO]): Resource[IO, Session[IO]] =
     Session.Builder[IO]
       .withUserAndPassword("jimmy", "banana")
       .withDatabase("world")
@@ -42,7 +42,7 @@ abstract class SkunkTest(debug: Boolean = false, typingStrategy: TypingStrategy 
       }
     }
 
-  def pooled(max: Int = 8, readTimeout: Duration = Duration.Inf, parseCacheSize: Int = 1024)(implicit tracer: Tracer[IO]): Resource[IO, Resource[IO, Session[IO]]] =
+  def pooled(max: Int = 8, readTimeout: Duration = Duration.Inf, parseCacheSize: Int = 1024)(implicit tracerProvider: TracerProvider[IO]): Resource[IO, Resource[IO, Session[IO]]] =
     Session.Builder[IO]
       .withUserAndPassword("jimmy", "banana")
       .withDatabase("world")

--- a/modules/tests/shared/src/test/scala/SslTest.scala
+++ b/modules/tests/shared/src/test/scala/SslTest.scala
@@ -6,7 +6,7 @@ package tests
 
 import cats.effect._
 import fs2.io.net.tls.SSLException
-import org.typelevel.otel4s.trace.Tracer
+import org.typelevel.otel4s.trace.TracerProvider
 import skunk._
 
 class SslTest extends ffstest.FTest {
@@ -17,7 +17,7 @@ class SslTest extends ffstest.FTest {
     val Trust   = 5433
   }
 
-  tracedTest("successful login with SSL.Trusted (ssl available)") { implicit tracer: Tracer[IO] =>
+  tracedTest("successful login with SSL.Trusted (ssl available)") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withUserAndPassword("jimmy", "banana")
       .withDatabase("world")
@@ -26,7 +26,7 @@ class SslTest extends ffstest.FTest {
       .use(_ => IO.unit)
   }
 
-  tracedTest("successful login with SSL.None (ssl available)") { implicit tracer: Tracer[IO] =>
+  tracedTest("successful login with SSL.None (ssl available)") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withUserAndPassword("jimmy", "banana")
       .withDatabase("world")
@@ -35,7 +35,7 @@ class SslTest extends ffstest.FTest {
       .use(_ => IO.unit)
   }
 
-  tracedTest("failed login with SSL.System (ssl available)") { implicit tracer: Tracer[IO] =>
+  tracedTest("failed login with SSL.System (ssl available)") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withUserAndPassword("jimmy", "banana")
       .withDatabase("world")
@@ -44,7 +44,7 @@ class SslTest extends ffstest.FTest {
       .use(_ => IO.unit).assertFailsWith[SSLException].as("sigh") // TODO! Better failure!
   }
 
-  tracedTest("failed login with SSL.Trusted (ssl not available)") { implicit tracer: Tracer[IO] =>
+  tracedTest("failed login with SSL.Trusted (ssl not available)") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withSSL(SSL.Trusted)
       .withDatabase("world")
@@ -53,7 +53,7 @@ class SslTest extends ffstest.FTest {
       .use(_ => IO.unit).assertFailsWith[Exception].as("ok") // TODO! Better failure!
   }
 
-  tracedTest("successful login with SSL.Trusted.withFallback(true) (ssl not available)") { implicit tracer: Tracer[IO] =>
+  tracedTest("successful login with SSL.Trusted.withFallback(true) (ssl not available)") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(Port.Trust)
       .withDatabase("world")
@@ -62,7 +62,7 @@ class SslTest extends ffstest.FTest {
       .use(_ => IO.unit)
   }
 
-  tracedTest("successful login with SSL.None (ssl not available)") { implicit tracer: Tracer[IO] =>
+  tracedTest("successful login with SSL.None (ssl not available)") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(Port.Trust)
       .withDatabase("world")

--- a/modules/tests/shared/src/test/scala/StartupTest.scala
+++ b/modules/tests/shared/src/test/scala/StartupTest.scala
@@ -7,7 +7,7 @@ package tests
 import cats.effect._
 import com.comcast.ip4s.UnknownHostException
 import fs2.io.net.ConnectException
-import org.typelevel.otel4s.trace.Tracer
+import org.typelevel.otel4s.trace.TracerProvider
 import skunk._
 import skunk.exception.SkunkException
 import skunk.exception.StartupException
@@ -23,7 +23,7 @@ class StartupTest extends ffstest.FTest {
     val Password = 5435
   }
 
-  tracedTest("md5 - successful login") { implicit tracer: Tracer[IO] =>
+  tracedTest("md5 - successful login") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(Port.MD5)
       .withUserAndPassword("jimmy", "banana")
@@ -32,7 +32,7 @@ class StartupTest extends ffstest.FTest {
       .use(_ => IO.unit)
   }
 
-  tracedTest("md5 - non-existent database") { implicit tracer: Tracer[IO] =>
+  tracedTest("md5 - non-existent database") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(Port.MD5)
       .withUserAndPassword("jimmy", "banana")
@@ -43,7 +43,7 @@ class StartupTest extends ffstest.FTest {
       .flatMap(e => assertEqual("code", e.code, "3D000"))
   }
 
-  tracedTest("md5 - missing password") { implicit tracer: Tracer[IO] =>
+  tracedTest("md5 - missing password") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(Port.MD5)
       .withUser("jimmy")
@@ -54,7 +54,7 @@ class StartupTest extends ffstest.FTest {
       .flatMap(e => assertEqual("message", e.message, "Password required."))
   }
 
-  tracedTest("md5 - incorrect user") { implicit tracer: Tracer[IO] =>
+  tracedTest("md5 - incorrect user") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(Port.MD5)
       .withUserAndPassword("frank", "banana")
@@ -65,7 +65,7 @@ class StartupTest extends ffstest.FTest {
       .flatMap(e => assertEqual("code", e.code, "28P01"))
   }
 
-  tracedTest("md5 - incorrect password") { implicit tracer: Tracer[IO] =>
+  tracedTest("md5 - incorrect password") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(Port.MD5)
       .withUserAndPassword("jimmy", "apple")
@@ -76,7 +76,7 @@ class StartupTest extends ffstest.FTest {
       .flatMap(e => assertEqual("code", e.code, "28P01"))
   }
 
-  tracedTest("trust - successful login") { implicit tracer: Tracer[IO] =>
+  tracedTest("trust - successful login") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(Port.Trust)
       .withDatabase("world")
@@ -85,7 +85,7 @@ class StartupTest extends ffstest.FTest {
   }
 
   // TODO: should this be an error?
-  tracedTest("trust - successful login, ignored password") { implicit tracer: Tracer[IO] =>
+  tracedTest("trust - successful login, ignored password") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(Port.Trust)
       .withUserAndPassword("postgres", "ignored")
@@ -94,7 +94,7 @@ class StartupTest extends ffstest.FTest {
       .use(_ => IO.unit)
   }
 
-  tracedTest("trust - non-existent database") { implicit tracer: Tracer[IO] =>
+  tracedTest("trust - non-existent database") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(Port.Trust)
       .withDatabase("bogus")
@@ -104,7 +104,7 @@ class StartupTest extends ffstest.FTest {
       .flatMap(e => assertEqual("code", e.code, "3D000"))
   }
 
-  tracedTest("trust - incorrect user") { implicit tracer: Tracer[IO] =>
+  tracedTest("trust - incorrect user") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(Port.Trust)
       .withUser("bogus")
@@ -115,7 +115,7 @@ class StartupTest extends ffstest.FTest {
       .flatMap(e => assertEqual("code", e.code, "28000"))
   }
 
-  tracedTest("scram - successful login") { implicit tracer: Tracer[IO] =>
+  tracedTest("scram - successful login") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(Port.Scram)
       .withUserAndPassword("jimmy", "banana")
@@ -124,7 +124,7 @@ class StartupTest extends ffstest.FTest {
       .use(_ => IO.unit)
   }
 
-  tracedTest("scram - non-existent database") { implicit tracer: Tracer[IO] =>
+  tracedTest("scram - non-existent database") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(Port.Scram)
       .withUserAndPassword("jimmy", "banana")
@@ -135,7 +135,7 @@ class StartupTest extends ffstest.FTest {
       .flatMap(e => assertEqual("code", e.code, "3D000"))
   }
 
-  tracedTest("scram - missing password") { implicit tracer: Tracer[IO] =>
+  tracedTest("scram - missing password") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(Port.Scram)
       .withUser("jimmy")
@@ -146,7 +146,7 @@ class StartupTest extends ffstest.FTest {
       .flatMap(e => assertEqual("message", e.message, "Password required."))
   }
 
-  tracedTest("scram - incorrect user") { implicit tracer: Tracer[IO] =>
+  tracedTest("scram - incorrect user") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(Port.Scram)
       .withUserAndPassword("frank", "banana")
@@ -157,7 +157,7 @@ class StartupTest extends ffstest.FTest {
       .flatMap(e => assertEqual("code", e.code, "28P01"))
   }
 
-  tracedTest("scram - incorrect password") { implicit tracer: Tracer[IO] =>
+  tracedTest("scram - incorrect password") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(Port.Scram)
       .withUserAndPassword("jimmy", "apple")
@@ -168,7 +168,7 @@ class StartupTest extends ffstest.FTest {
       .flatMap(e => assertEqual("code", e.code, "28P01"))
   }
 
-  tracedTest("password - successful login") { implicit tracer: Tracer[IO] =>
+  tracedTest("password - successful login") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(Port.Password)
       .withUserAndPassword("jimmy", "banana")
@@ -177,7 +177,7 @@ class StartupTest extends ffstest.FTest {
       .use(_ => IO.unit)
   }
 
-  tracedTest("password - non-existent database") { implicit tracer: Tracer[IO] =>
+  tracedTest("password - non-existent database") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(Port.Password)
       .withUserAndPassword("jimmy", "banana")
@@ -188,7 +188,7 @@ class StartupTest extends ffstest.FTest {
       .flatMap(e => assertEqual("code", e.code, "3D000"))
   }
 
-  tracedTest("password - missing password") { implicit tracer: Tracer[IO] =>
+  tracedTest("password - missing password") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(Port.Password)
       .withUser("jimmy")
@@ -199,7 +199,7 @@ class StartupTest extends ffstest.FTest {
       .flatMap(e => assertEqual("message", e.message, "Password required."))
   }
 
-  tracedTest("password - incorrect user") { implicit tracer: Tracer[IO] =>
+  tracedTest("password - incorrect user") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(Port.Password)
       .withUserAndPassword("frank", "banana")
@@ -210,7 +210,7 @@ class StartupTest extends ffstest.FTest {
       .flatMap(e => assertEqual("code", e.code, "28P01"))
   }
 
-  tracedTest("password - incorrect password") { implicit tracer: Tracer[IO] =>
+  tracedTest("password - incorrect password") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(Port.Password)
       .withUserAndPassword("jimmy", "apple")
@@ -221,7 +221,7 @@ class StartupTest extends ffstest.FTest {
       .flatMap(e => assertEqual("code", e.code, "28P01"))
   }
 
-  tracedTest("invalid port") { implicit tracer: Tracer[IO] =>
+  tracedTest("invalid port") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withPort(Port.Invalid)
       .withUserAndPassword("jimmy", "banana")
@@ -230,7 +230,7 @@ class StartupTest extends ffstest.FTest {
       .use(_ => IO.unit).assertFailsWith[ConnectException]
   }
 
-  tracedTest("invalid host") { implicit tracer: Tracer[IO] =>
+  tracedTest("invalid host") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withHost("blergh")
       .withPort(Port.Invalid)
@@ -242,7 +242,7 @@ class StartupTest extends ffstest.FTest {
 
   object LinuxOnly extends munit.Tag("LinuxOnly")
 
-  tracedTest("unix domain sockets - successful login".tag(LinuxOnly)) { implicit tracer: Tracer[IO] =>
+  tracedTest("unix domain sockets - successful login".tag(LinuxOnly)) { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withUnixSocketDirectory("test-unix-socket")
       .withUser("jimmy")

--- a/modules/tests/shared/src/test/scala/codec/TemporalCodecTest.scala
+++ b/modules/tests/shared/src/test/scala/codec/TemporalCodecTest.scala
@@ -11,7 +11,7 @@ import org.typelevel.cats.time.{ offsetdatetimeInstances => _, _ }
 import java.time._
 import skunk.codec.temporal._
 import cats.effect.{IO, Resource}
-import org.typelevel.otel4s.trace.Tracer
+import org.typelevel.otel4s.trace.TracerProvider
 import skunk._, skunk.implicits._
 import scala.concurrent.duration.{ Duration => SDuration }
 
@@ -25,7 +25,7 @@ class TemporalCodecTest extends CodecTest {
 
   // Also, run these tests with the session set to a timezone other than UTC. Our test instance is
   // set to UTC, which masks the error reported at https://github.com/tpolecat/skunk/issues/313.
-  override def session(readTimeout: SDuration)(implicit tracer: Tracer[IO]): Resource[IO,Session[IO]] =
+  override def session(readTimeout: SDuration)(implicit tracerProvider: TracerProvider[IO]): Resource[IO,Session[IO]] =
     super.session(readTimeout).evalTap(s => s.execute(sql"SET TIME ZONE +3".command))
 
   // Date

--- a/modules/tests/shared/src/test/scala/issue/210.scala
+++ b/modules/tests/shared/src/test/scala/issue/210.scala
@@ -10,7 +10,7 @@ import skunk.codec.all._
 import skunk.implicits._
 import tests.SkunkTest
 import cats.effect._
-import org.typelevel.otel4s.trace.Tracer
+import org.typelevel.otel4s.trace.TracerProvider
 
 // https://github.com/tpolecat/skunk/issues/210
 class Test210 extends SkunkTest {
@@ -47,7 +47,7 @@ class Test210 extends SkunkTest {
   val bob     = Pet("Bob", 12)
   val beatles = List(Pet("John", 2), Pet("George", 3), Pet("Paul", 6), Pet("Ringo", 3))
 
-  def doInserts(ready: Deferred[IO, Unit], done: Deferred[IO, Unit])(implicit tracer: Tracer[IO]): IO[Unit] =
+  def doInserts(ready: Deferred[IO, Unit], done: Deferred[IO, Unit])(implicit tracerProvider: TracerProvider[IO]): IO[Unit] =
     session.flatTap(withPetsTable).use { s =>
       for {
         _ <- s.prepare(insertOne).flatMap(pc => pc.execute(Pet("Bob", 12)))
@@ -57,7 +57,7 @@ class Test210 extends SkunkTest {
       } yield ()
     }
 
-  def check(implicit tracer: Tracer[IO]): IO[Unit] =
+  def check(implicit tracerProvider: TracerProvider[IO]): IO[Unit] =
     session.use { s =>
       for {
         ns <- s.execute(sql"select name from Test210_pets".query(varchar))
@@ -65,7 +65,7 @@ class Test210 extends SkunkTest {
       } yield ()
     }
 
-  tracedTest("issue/210") { implicit tracer: Tracer[IO] =>
+  tracedTest("issue/210") { implicit tracerProvider: TracerProvider[IO] =>
     for {
       ready <- Deferred[IO, Unit]
       done  <- Deferred[IO, Unit]

--- a/modules/tests/shared/src/test/scala/issue/238.scala
+++ b/modules/tests/shared/src/test/scala/issue/238.scala
@@ -5,12 +5,12 @@
 package tests.issue
 
 import cats.effect._
-import org.typelevel.otel4s.trace.Tracer
+import org.typelevel.otel4s.trace.TracerProvider
 import skunk._
 
 class Test238 extends ffstest.FTest {
 
-  tracedTest("see (https://github.com/functional-streams-for-scala/fs2/pull/1989)") { implicit tracer: Tracer[IO] =>
+  tracedTest("see (https://github.com/functional-streams-for-scala/fs2/pull/1989)") { implicit tracerProvider: TracerProvider[IO] =>
     Session.Builder[IO]
       .withUserAndPassword("jimmy", "banana")
       .withDatabase("world")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,3 +11,4 @@ addSbtPlugin("org.scoverage"      % "sbt-scoverage"                             
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"                                 % "1.22.0")
 addSbtPlugin("org.scala-native"   % "sbt-scala-native"                            % "0.5.12")
 addSbtPlugin("com.armanbilge"     % "sbt-scala-native-config-brew-github-actions" % "0.4.0")
+addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"                               % "0.13.1")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.4.3")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.7.0")


### PR DESCRIPTION
## Motivation

OpenTelemetry recommends libraries to **own** their instrumentation scopes. 
A few benefits:
1) Full control of the namespace - the traces & metrics will belong to the `org.typelevel.skunk` - which simplifies the filtering
2) Every release will be reflected in the instrumentation scope version - much easier to spot regressions and filter traces/metrics if needed

____

https://opentelemetry.io/docs/concepts/instrumentation-scope/

> For libraries and frameworks: use the library’s fully qualified name and version as the scope. If you are writing an instrumentation library for a library that has no built-in OpenTelemetry support, use the name and version of the instrumentation library itself.

